### PR TITLE
feat: add Latest Writing blog section to landing page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Personal landing page for Jeremy Longshore built with **Linkyee** (Ruby-based static site generator). Single-page design featuring project links, social profiles, and dynamic GitHub star counts.
 
 **Live:** https://jeremylongshore.com
-**Deployment:** Firebase Hosting via GitHub Actions (builds on push to main)
+**Deployment:** Contabo VPS `intentsolutions` (`167.86.106.29`, Caddy). Verified via `dig +short jeremylongshore.com` 2026-07-16. Migrated off Firebase Hosting + Netlify on 2026-06-20. **NOT Firebase, NOT Netlify** — the repo still carries a stale `firebase-deploy.yml`/`netlify.toml` from the old hosts. Confirm the current pipeline against `~/.claude/CLAUDE.md` § "Cloud Platform" and the VPS runbook before touching deploy.
 
 ## Commands
 
@@ -72,11 +72,10 @@ text: "Project <span class='link-button-text'>({{vars.GithubRepoStarsCountPlugin
 
 ## Deployment
 
-- **Host:** Firebase Hosting (project: `bigo-portfolio`)
-- **Trigger:** Push to `main` branch
-- **Workflow:** `.github/workflows/firebase-deploy.yml`
-- **Auth:** Workload Identity Federation (no service account keys)
-- **Caching:** 1-year cache for images, CSS, JS
+- **Host:** Contabo VPS `intentsolutions` (`167.86.106.29`), served by Caddy. `dig`-verified 2026-07-16.
+- **History:** Migrated 2026-06-20 off **Firebase Hosting** (project `bigo-portfolio`) and Netlify. The old Firebase note (WIF auth, 1-year caching, push-to-`main` trigger) described the retired host, not the live one.
+- **Stale artifacts:** `.github/workflows/firebase-deploy.yml` and `netlify.toml` remain in the repo from the prior hosts — they do not reflect the live pipeline. Do not treat them as authoritative.
+- **Source of truth for the live pipeline:** `~/.claude/CLAUDE.md` § "Cloud Platform" + the VPS runbook (`~/000-projects/intentsolutions-vps-runbook/`). Verify the host with `dig`, not this file.
 
 ## Dependencies
 

--- a/_output/index.html
+++ b/_output/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jeremy Longshore - I Make Teams AI-Native</title>
-  <meta name="last-modified" content="2026-03-06T13:25:00-0600">
+  <meta name="last-modified" content="2026-03-25T00:49:08-0500">
   <meta name="theme-color" content="#FFFFFF">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="description" content="I build AI systems that ship and train teams to work with coding agents — Claude, Codex, Gemini, whatever moves the needle. 20+ years ops, self-taught dev, 60+ repos with real GitHub stars." />
@@ -15,7 +15,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="./images/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="./images/favicons/favicon-32x32.png">
   <link rel="shortcut icon" href="./images/favicons/favicon.ico">
-  <link rel="stylesheet" href="./styles.css?v=2026-03-06T13:25:00-0600" />
+  <link rel="stylesheet" href="./styles.css?v=2026-03-25T00:49:08-0500" />
 </head>
 <body>
   <div class="container">
@@ -92,7 +92,7 @@
             
               
               
-                <span class="badge stars">1530 Stars</span>
+                <span class="badge stars">1708 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -124,7 +124,7 @@
             
               
               
-                <span class="badge stars">7 Stars</span>
+                <span class="badge stars">11 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -156,7 +156,7 @@
             
               
               
-                <span class="badge stars">7 Stars</span>
+                <span class="badge stars">8 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -206,6 +206,38 @@
             
           </div>
           <a href="https://startaitools.com" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
+      <div class="link-item" data-id="hybrid-ai-stack">
+        <div class="link-row" onclick="toggleExpand('hybrid-ai-stack')">
+          <div class="link-icon"><i class="fa-solid fa-layer-group"></i></div>
+          <div class="link-text">
+            <span class="link-title">Hybrid AI Stack</span>
+            <span class="link-desc">Reference architecture: Vertex AI + Firebase + Cloud Run</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">2 Stars</span>
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-hybrid-ai-stack">
+          <p class="expand-desc">Reference architecture for building hybrid AI systems on Google Cloud. Combines Vertex AI, Firebase, and Cloud Run for production-grade AI applications.</p>
+          
+          <ul class="expand-list">
+            <li>Production AI architecture patterns</li><li>Google Cloud AI integrations</li><li>Hybrid cloud + AI deployments</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Google Cloud</span><span class="tag tech">Vertex AI</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Run</span>
+            <span class="tag agent">Vertex AI</span>
+          </div>
+          <a href="https://github.com/jeremylongshore/Hybrid-ai-stack-intent-solutions" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -274,12 +306,12 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="hybrid-ai-stack">
-        <div class="link-row" onclick="toggleExpand('hybrid-ai-stack')">
-          <div class="link-icon"><i class="fa-solid fa-layer-group"></i></div>
+      <div class="link-item" data-id="irsb">
+        <div class="link-row" onclick="toggleExpand('irsb')">
+          <div class="link-icon"><i class="fa-brands fa-ethereum"></i></div>
           <div class="link-text">
-            <span class="link-title">Hybrid AI Stack</span>
-            <span class="link-desc">Reference architecture: Vertex AI + Firebase + Cloud Run</span>
+            <span class="link-title">IRSB</span>
+            <span class="link-desc">EIP-7702 spend limits + on-chain receipts for intent accountability</span>
           </div>
           <div class="link-badge">
             
@@ -292,18 +324,18 @@
             <span class="expand-icon">+</span>
           </div>
         </div>
-        <div class="link-expand" id="expand-hybrid-ai-stack">
-          <p class="expand-desc">Reference architecture for building hybrid AI systems on Google Cloud. Combines Vertex AI, Firebase, and Cloud Run for production-grade AI applications.</p>
+        <div class="link-expand" id="expand-irsb">
+          <p class="expand-desc">Intent Receipts & Solver Bonds (IRSB) - Consolidated monorepo containing the Ethereum protocol, solver, watchtower, and agent components. Features EIP-7702 spend limits, execution receipts with cryptographic proofs, dispute resolution, and automated slashing for timeouts and constraint violations. Includes watchtower service for real-time on-chain monitoring and violation detection.</p>
           
           <ul class="expand-list">
-            <li>Production AI architecture patterns</li><li>Google Cloud AI integrations</li><li>Hybrid cloud + AI deployments</li>
+            <li>On-chain intent receipts with cryptographic proofs</li><li>EIP-7702 spend limits and execution receipts</li><li>Automated dispute resolution and slashing</li><li>Real-time watchtower monitoring of solver behavior</li>
           </ul>
           
           <div class="expand-tags">
-            <span class="tag tech">Google Cloud</span><span class="tag tech">Vertex AI</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Run</span>
-            <span class="tag agent">Vertex AI</span>
+            <span class="tag tech">Solidity</span><span class="tag tech">Foundry</span><span class="tag tech">Ethereum</span><span class="tag tech">ERC-7683</span>
+            
           </div>
-          <a href="https://github.com/jeremylongshore/Hybrid-ai-stack-intent-solutions" target="_blank" class="expand-link">Open &rarr;</a>
+          <a href="https://irsb-protocol.web.app" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -370,36 +402,6 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="irsb">
-        <div class="link-row" onclick="toggleExpand('irsb')">
-          <div class="link-icon"><i class="fa-brands fa-ethereum"></i></div>
-          <div class="link-text">
-            <span class="link-title">IRSB</span>
-            <span class="link-desc">EIP-7702 spend limits + on-chain receipts for intent accountability</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-irsb">
-          <p class="expand-desc">Intent Receipts & Solver Bonds (IRSB) - Consolidated monorepo containing the Ethereum protocol, solver, watchtower, and agent components. Features EIP-7702 spend limits, execution receipts with cryptographic proofs, dispute resolution, and automated slashing for timeouts and constraint violations. Includes watchtower service for real-time on-chain monitoring and violation detection.</p>
-          
-          <ul class="expand-list">
-            <li>On-chain intent receipts with cryptographic proofs</li><li>EIP-7702 spend limits and execution receipts</li><li>Automated dispute resolution and slashing</li><li>Real-time watchtower monitoring of solver behavior</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Solidity</span><span class="tag tech">Foundry</span><span class="tag tech">Ethereum</span><span class="tag tech">ERC-7683</span>
-            
-          </div>
-          <a href="https://irsb-protocol.web.app" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
       <div class="link-item" data-id="lumera-agent-memory">
         <div class="link-row" onclick="toggleExpand('lumera-agent-memory')">
           <div class="link-icon"><i class="fa-solid fa-brain"></i></div>
@@ -451,7 +453,7 @@
             
               
               
-                <span class="badge stars">25 Stars</span>
+                <span class="badge stars">26 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -483,7 +485,7 @@
             
               
               
-                <span class="badge stars">16 Stars</span>
+                <span class="badge stars">19 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -547,7 +549,7 @@
             
               
               
-                <span class="badge stars">5 Stars</span>
+                <span class="badge stars">6 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -600,6 +602,38 @@
         </div>
       </div>
       
+      <div class="link-item" data-id="executive-intent">
+        <div class="link-row" onclick="toggleExpand('executive-intent')">
+          <div class="link-icon"><i class="fa-solid fa-shield-check"></i></div>
+          <div class="link-text">
+            <span class="link-title">Executive Intent</span>
+            <span class="link-desc">DLP-enforced Gmail/Calendar intelligence with audit receipts</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">2 Stars</span>
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-executive-intent">
+          <p class="expand-desc">Enterprise security pipeline that transforms Gmail and Calendar data into a governed, DLP-screened knowledge base. Ingests email and calendar metadata through OAuth, applies Nightfall DLP enforcement (allow/redact/quarantine), indexes content with pgvector embeddings, and enables semantic retrieval with documented provenance. Every query returns audit receipts tied to build and deploy pipelines.</p>
+          
+          <ul class="expand-list">
+            <li>Secure executive email intelligence with DLP compliance</li><li>Semantic search across email and calendar with audit trails</li><li>Evidence bundles for compliance and legal discovery</li><li>Real-time DLP enforcement on sensitive communications</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Next.js</span><span class="tag tech">Supabase</span><span class="tag tech">pgvector</span><span class="tag tech">Inngest</span>
+            <span class="tag agent">Nightfall DLP</span><span class="tag agent">OpenAI Embeddings</span>
+          </div>
+          <a href="https://executive-intent.web.app" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
       <div class="link-item" data-id="bounties">
         <div class="link-row" onclick="toggleExpand('bounties')">
           <div class="link-icon"><i class="fa-solid fa-bullseye"></i></div>
@@ -633,12 +667,12 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="executive-intent">
-        <div class="link-row" onclick="toggleExpand('executive-intent')">
-          <div class="link-icon"><i class="fa-solid fa-shield-check"></i></div>
+      <div class="link-item" data-id="diagnosticpro">
+        <div class="link-row" onclick="toggleExpand('diagnosticpro')">
+          <div class="link-icon"><i class="fa-solid fa-wrench"></i></div>
           <div class="link-text">
-            <span class="link-title">Executive Intent</span>
-            <span class="link-desc">DLP-enforced Gmail/Calendar intelligence with audit receipts</span>
+            <span class="link-title">DiagnosticPro</span>
+            <span class="link-desc">Photo-to-diagnosis: upload a pic, get a repair plan</span>
           </div>
           <div class="link-badge">
             
@@ -651,18 +685,18 @@
             <span class="expand-icon">+</span>
           </div>
         </div>
-        <div class="link-expand" id="expand-executive-intent">
-          <p class="expand-desc">Enterprise security pipeline that transforms Gmail and Calendar data into a governed, DLP-screened knowledge base. Ingests email and calendar metadata through OAuth, applies Nightfall DLP enforcement (allow/redact/quarantine), indexes content with pgvector embeddings, and enables semantic retrieval with documented provenance. Every query returns audit receipts tied to build and deploy pipelines.</p>
+        <div class="link-expand" id="expand-diagnosticpro">
+          <p class="expand-desc">Consumer-facing AI diagnostic platform that helps users troubleshoot equipment issues using Vertex AI Gemini. Upload photos or describe symptoms, and get instant AI-powered diagnosis with repair cost estimates and step-by-step fix instructions. Covers vehicles, appliances, HVAC, and more. Pay-per-diagnosis model at $4.99 makes professional-grade diagnostics accessible to everyone.</p>
           
           <ul class="expand-list">
-            <li>Secure executive email intelligence with DLP compliance</li><li>Semantic search across email and calendar with audit trails</li><li>Evidence bundles for compliance and legal discovery</li><li>Real-time DLP enforcement on sensitive communications</li>
+            <li>Diagnose vehicle issues from symptoms or photos</li><li>Get accurate repair cost estimates before visiting a shop</li><li>Follow AI-guided troubleshooting steps</li><li>Track maintenance history and upcoming service needs</li>
           </ul>
           
           <div class="expand-tags">
-            <span class="tag tech">Next.js</span><span class="tag tech">Supabase</span><span class="tag tech">pgvector</span><span class="tag tech">Inngest</span>
-            <span class="tag agent">Nightfall DLP</span><span class="tag agent">OpenAI Embeddings</span>
+            <span class="tag tech">React</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Functions</span><span class="tag tech">Firestore</span>
+            <span class="tag agent">Vertex AI Gemini</span>
           </div>
-          <a href="https://executive-intent.web.app" target="_blank" class="expand-link">Open &rarr;</a>
+          <a href="https://diagnosticpro.io" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -729,36 +763,6 @@
             <span class="tag agent">MCP Servers</span>
           </div>
           <a href="https://github.com/intent-solutions-io/intent-mail" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
-      <div class="link-item" data-id="diagnosticpro">
-        <div class="link-row" onclick="toggleExpand('diagnosticpro')">
-          <div class="link-icon"><i class="fa-solid fa-wrench"></i></div>
-          <div class="link-text">
-            <span class="link-title">DiagnosticPro</span>
-            <span class="link-desc">Photo-to-diagnosis: upload a pic, get a repair plan</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-diagnosticpro">
-          <p class="expand-desc">Consumer-facing AI diagnostic platform that helps users troubleshoot equipment issues using Vertex AI Gemini. Upload photos or describe symptoms, and get instant AI-powered diagnosis with repair cost estimates and step-by-step fix instructions. Covers vehicles, appliances, HVAC, and more. Pay-per-diagnosis model at $4.99 makes professional-grade diagnostics accessible to everyone.</p>
-          
-          <ul class="expand-list">
-            <li>Diagnose vehicle issues from symptoms or photos</li><li>Get accurate repair cost estimates before visiting a shop</li><li>Follow AI-guided troubleshooting steps</li><li>Track maintenance history and upcoming service needs</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">React</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Functions</span><span class="tag tech">Firestore</span>
-            <span class="tag agent">Vertex AI Gemini</span>
-          </div>
-          <a href="https://diagnosticpro.io" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -934,7 +938,7 @@
             
               
               
-                <span class="badge stars">24 Stars</span>
+                <span class="badge stars">29 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -966,6 +970,9 @@
             
               
               
+                <span class="badge stars">1 Star</span>
+                
+              
             
             <span class="expand-icon">+</span>
           </div>
@@ -996,6 +1003,9 @@
             
               
               
+                <span class="badge stars">1 Star</span>
+                
+              
             
             <span class="expand-icon">+</span>
           </div>
@@ -1012,6 +1022,39 @@
             <span class="tag agent">Vertex AI Agent Engine</span><span class="tag agent">A2A Protocol</span>
           </div>
           <a href="https://hustlestats.io" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
+      <div class="link-item" data-id="stci">
+        <div class="link-row" onclick="toggleExpand('stci')">
+          <div class="link-icon"><i class="fa-solid fa-chart-line"></i></div>
+          <div class="link-text">
+            <span class="link-title">STCI</span>
+            <span class="link-desc">Daily LLM pricing across every major provider, free API</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">1 Star</span>
+                
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-stci">
+          <p class="expand-desc">The Standard Token Cost Index - a daily benchmark tracking LLM API pricing across OpenAI, Anthropic, Google, DeepSeek, and other providers. Historical price tracking shows cost trends over time. Free public API endpoint lets developers query current prices programmatically. Essential resource for teams optimizing AI infrastructure costs and making informed provider decisions.</p>
+          
+          <ul class="expand-list">
+            <li>Compare LLM API pricing across providers</li><li>Track historical price changes and trends</li><li>Free API endpoint for programmatic access</li><li>Optimize AI infrastructure costs</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Python</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Scheduler</span><span class="tag tech">FastAPI</span>
+            
+          </div>
+          <a href="https://inferencepriceindex.com" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -1098,36 +1141,6 @@
             <span class="tag agent">Google ADK</span><span class="tag agent">Vertex AI Agent Engine</span>
           </div>
           <a href="https://pipelinepilot-prod.web.app" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
-      <div class="link-item" data-id="stci">
-        <div class="link-row" onclick="toggleExpand('stci')">
-          <div class="link-icon"><i class="fa-solid fa-chart-line"></i></div>
-          <div class="link-text">
-            <span class="link-title">STCI</span>
-            <span class="link-desc">Daily LLM pricing across every major provider, free API</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-stci">
-          <p class="expand-desc">The Standard Token Cost Index - a daily benchmark tracking LLM API pricing across OpenAI, Anthropic, Google, DeepSeek, and other providers. Historical price tracking shows cost trends over time. Free public API endpoint lets developers query current prices programmatically. Essential resource for teams optimizing AI infrastructure costs and making informed provider decisions.</p>
-          
-          <ul class="expand-list">
-            <li>Compare LLM API pricing across providers</li><li>Track historical price changes and trends</li><li>Free API endpoint for programmatic access</li><li>Optimize AI infrastructure costs</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Python</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Scheduler</span><span class="tag tech">FastAPI</span>
-            
-          </div>
-          <a href="https://inferencepriceindex.com" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -1270,7 +1283,7 @@
           
             
             
-              <span class="badge stars">10 Stars</span>
+              <span class="badge stars">11 Stars</span>
             
           
         </div>
@@ -1355,6 +1368,106 @@
       </ul>
       <a href="https://calendar.app.google/Wqbt8EJuEh5xvvV58" target="_blank" class="cta-link">Let's talk →</a>
     </section>
+
+    
+    <section class="links blog-section">
+      <a href="https://startaitools.com/posts/" target="_blank" class="section-header">
+        <h2 class="section-label">Latest Writing</h2>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+      </a>
+      <p class="section-intro">Technical deep-dives on AI agents, plugin development, and production systems.</p>
+      
+      <a href="https://startaitools.com/posts/x-bug-triage-plugin-zero-to-v043-one-day/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">X Bug Triage Plugin: Zero to v0.4.3 in One Day</span>
+          <span class="link-desc">A brand-new MCP plugin that triages X/Twitter bug reports shipped 10 epics, 13 releases, 89 tests, and 4 extracted sub-agents.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-23</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/ninety-skills-three-packs-one-day/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Ninety Skills, Three Packs, One Day</span>
+          <span class="link-desc">Building three complete 30-skill SaaS integration packs — Sentry, Notion, and Supabase — in a single day.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-22</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/nuclear-option-day-validator-rewrite-414-plugins/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Nuclear Option Day: Validator Rewrite, 63 New Packs, 414 Plugins</span>
+          <span class="link-desc">Rewrote the universal validator from scratch to match Anthropic's 14-field spec, generated 63 SaaS packs.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-21</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/58-e2e-tests-slack-channel-launch-one-day/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">58 E2E Tests, a Slack Channel Launch, and the Auth Injection That Made It Work</span>
+          <span class="link-desc">How REST API auth plus IndexedDB injection unlocked 58 production E2E tests for cad-dxf-agent.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-20</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/governed-knowledge-two-releases-freshness-daemon/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Governed Knowledge: Two Major Releases, a Freshness Daemon, and Export Gating</span>
+          <span class="link-desc">qmd-team-intent-kb ships v0.2.0 and v0.3.0 in one day — freshness-aware search with exponential decay.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-19</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/knowledge-base-zero-to-api-lifecycle-state-machine/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Knowledge Base from Zero to API: Lifecycle State Machines and Policy Engines</span>
+          <span class="link-desc">Building a team knowledge base with lifecycle state machines, policy engines, and git-exported articles.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-18</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/content-quality-war-7-check-audit-across-340-plugins/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Content Quality War: 7-Check Audit Across 340 Plugins</span>
+          <span class="link-desc">A 7-category audit script found boilerplate openings, empty shells, reference stubs, and duplicate content.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-17</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/meta-agent-orchestration-and-the-ux-of-removing-features/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Meta-Agent Orchestration and the UX of Removing Features</span>
+          <span class="link-desc">The oss-agent-lab ships its meta-agent capstone — one agent to orchestrate nine specialists.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-16</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/" target="_blank" class="view-all-link">View all posts →</a>
+    </section>
+    
 
     <nav class="socials">
       

--- a/_output/styles.css
+++ b/_output/styles.css
@@ -425,6 +425,30 @@ a.section-header:hover i {
   color: #2E7D32;
 }
 
+.badge.date {
+  background: #EDE7F6;
+  color: #5E35B1;
+  font-variant-numeric: tabular-nums;
+}
+
+.blog-section .section-intro {
+  margin-bottom: 4px;
+}
+
+.view-all-link {
+  display: block;
+  text-align: center;
+  margin-top: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #2563EB;
+  text-decoration: none;
+  padding: 8px;
+}
+.view-all-link:hover {
+  text-decoration: underline;
+}
+
 .expand-icon {
   width: 24px;
   height: 24px;

--- a/data/blog_posts.yml
+++ b/data/blog_posts.yml
@@ -1,0 +1,39 @@
+- title: "X Bug Triage Plugin: Zero to v0.4.3 in One Day"
+  date: "2026-03-23"
+  description: "A brand-new MCP plugin that triages X/Twitter bug reports shipped 10 epics, 13 releases, 89 tests, and 4 extracted sub-agents."
+  url: "https://startaitools.com/posts/x-bug-triage-plugin-zero-to-v043-one-day/"
+
+- title: "Ninety Skills, Three Packs, One Day"
+  date: "2026-03-22"
+  description: "Building three complete 30-skill SaaS integration packs — Sentry, Notion, and Supabase — in a single day."
+  url: "https://startaitools.com/posts/ninety-skills-three-packs-one-day/"
+
+- title: "Nuclear Option Day: Validator Rewrite, 63 New Packs, 414 Plugins"
+  date: "2026-03-21"
+  description: "Rewrote the universal validator from scratch to match Anthropic's 14-field spec, generated 63 SaaS packs."
+  url: "https://startaitools.com/posts/nuclear-option-day-validator-rewrite-414-plugins/"
+
+- title: "58 E2E Tests, a Slack Channel Launch, and the Auth Injection That Made It Work"
+  date: "2026-03-20"
+  description: "How REST API auth plus IndexedDB injection unlocked 58 production E2E tests for cad-dxf-agent."
+  url: "https://startaitools.com/posts/58-e2e-tests-slack-channel-launch-one-day/"
+
+- title: "Governed Knowledge: Two Major Releases, a Freshness Daemon, and Export Gating"
+  date: "2026-03-19"
+  description: "qmd-team-intent-kb ships v0.2.0 and v0.3.0 in one day — freshness-aware search with exponential decay."
+  url: "https://startaitools.com/posts/governed-knowledge-two-releases-freshness-daemon/"
+
+- title: "Knowledge Base from Zero to API: Lifecycle State Machines and Policy Engines"
+  date: "2026-03-18"
+  description: "Building a team knowledge base with lifecycle state machines, policy engines, and git-exported articles."
+  url: "https://startaitools.com/posts/knowledge-base-zero-to-api-lifecycle-state-machine/"
+
+- title: "Content Quality War: 7-Check Audit Across 340 Plugins"
+  date: "2026-03-17"
+  description: "A 7-category audit script found boilerplate openings, empty shells, reference stubs, and duplicate content."
+  url: "https://startaitools.com/posts/content-quality-war-7-check-audit-across-340-plugins/"
+
+- title: "Meta-Agent Orchestration and the UX of Removing Features"
+  date: "2026-03-16"
+  description: "The oss-agent-lab ships its meta-agent capstone — one agent to orchestrate nine specialists."
+  url: "https://startaitools.com/posts/meta-agent-orchestration-and-the-ux-of-removing-features/"

--- a/scaffold.rb
+++ b/scaffold.rb
@@ -29,6 +29,14 @@ else
   settings["projects"] = []
 end
 
+# Load blog posts from data file
+blog_posts_file = "./data/blog_posts.yml"
+if File.exist?(blog_posts_file)
+  settings["blog_posts"] = YAML.load_file(blog_posts_file) || []
+else
+  settings["blog_posts"] = []
+end
+
 # Collect GitHub repos from all projects for star fetching
 all_projects = settings["intent_solutions_repos"] + settings["products"] + settings["personal_repos"] + settings["client_projects"] + settings["n8n_workflows"]
 github_repos = all_projects

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -328,6 +328,29 @@
       <a href="{{ booking_url }}" target="_blank" class="cta-link">Let's talk →</a>
     </section>
 
+    {% if blog_posts.size > 0 %}
+    <section class="links blog-section">
+      <a href="https://startaitools.com/posts/" target="_blank" class="section-header">
+        <h2 class="section-label">Latest Writing</h2>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+      </a>
+      <p class="section-intro">Technical deep-dives on AI agents, plugin development, and production systems.</p>
+      {% for post in blog_posts %}
+      <a href="{{ post.url }}" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">{{ post.title }}</span>
+          <span class="link-desc">{{ post.description }}</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">{{ post.date }}</span>
+        </div>
+      </a>
+      {% endfor %}
+      <a href="https://startaitools.com/posts/" target="_blank" class="view-all-link">View all posts →</a>
+    </section>
+    {% endif %}
+
     <nav class="socials">
       {% for item in socials %}
       {% assign s = item.social %}

--- a/themes/default/styles.css
+++ b/themes/default/styles.css
@@ -425,6 +425,30 @@ a.section-header:hover i {
   color: #2E7D32;
 }
 
+.badge.date {
+  background: #EDE7F6;
+  color: #5E35B1;
+  font-variant-numeric: tabular-nums;
+}
+
+.blog-section .section-intro {
+  margin-bottom: 4px;
+}
+
+.view-all-link {
+  display: block;
+  text-align: center;
+  margin-top: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #2563EB;
+  text-decoration: none;
+  padding: 8px;
+}
+.view-all-link:hover {
+  text-decoration: underline;
+}
+
 .expand-icon {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
## Summary

- Adds a "Latest Writing" section to the jeremylongshore.com landing page
- Surfaces 8 most recent posts from startaitools.com with date badges and descriptions
- Data-driven via `data/blog_posts.yml`, loaded in `scaffold.rb`
- Matches existing link card design with purple date badges
- "View all posts" link to startaitools.com/posts/

## Test plan

- [x] `bash build.sh` passes clean
- [x] Blog section appears in `_output/index.html` with 8 posts
- [x] All links point to correct startaitools.com/posts/ URLs
- [ ] Visual check on localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)