### PR TITLE
fix(deploy): restore Firebase production deploy + correct docs

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "bigo-portfolio"
+  }
+}

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Build site
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bundle install
+          bundle exec ruby scaffold.rb
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/409656019618/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'github-actions@bigo-portfolio.iam.gserviceaccount.com'
+
+      - name: Setup Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy to Firebase Hosting
+        run: firebase deploy --only hosting --project bigo-portfolio

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ _hugo_backup/
 .github_stars_cache.json
 .github_contributions_cache.json
 .rss_cache.json
+.firebase/
 vendor/
 
 # Dolt database files (added by bd init)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Personal landing page for Jeremy Longshore built with **Linkyee** (Ruby-based static site generator). Single-page design featuring project links, social profiles, and dynamic GitHub star counts.
 
 **Live:** https://jeremylongshore.com
-**Deployment:** Netlify (auto-deploys `main`; serves the committed `_output/` directly)
+**Deployment:** Firebase Hosting (`bigo-portfolio`) via `.github/workflows/firebase-deploy.yml` on push to `main`. Netlify is connected for PR deploy previews only — it does NOT serve the live domain.
 
 ## Commands
 
@@ -76,20 +76,28 @@ text: "Project <span class='link-button-text'>({{vars.GithubRepoStarsCountPlugin
 
 ## Deployment
 
-**Netlify** is the live deploy for jeremylongshore.com, wired via the Netlify
-GitHub app (not a workflow in this repo):
+**Firebase Hosting** (project `bigo-portfolio`) serves the live domain. Apex
+`jeremylongshore.com` and `www` both point at Firebase (A `199.36.158.100`).
 
-- **Host:** Netlify — serves the committed `_output/` directly (`netlify.toml`:
-  `publish = "_output"`, no build command). Whatever `_output/` you commit is
-  what ships.
-- **Trigger:** push to `main` → production deploy; every PR gets a deploy preview
-  at `deploy-preview-<N>--jeremylongshore.netlify.app`.
+- **Production deploy:** `.github/workflows/firebase-deploy.yml` runs on push to
+  `main` — builds with `scaffold.rb` (`GITHUB_TOKEN` in env), authenticates to
+  GCP via Workload Identity Federation (pool `github-pool`, SA
+  `github-actions@bigo-portfolio.iam.gserviceaccount.com`), then
+  `firebase deploy --only hosting`.
+- **Manual deploy:** `bash build.sh && firebase deploy --only hosting --project bigo-portfolio`.
+- **Netlify is PREVIEW-ONLY:** the Netlify GitHub app builds a deploy preview per
+  PR (`deploy-preview-<N>--jeremylongshore.netlify.app`). It does **not** serve
+  the production domain.
 - **Build-time data** (stars, contributions, RSS) is baked into `_output/` at
-  commit time — run `bash build.sh` and commit `_output/` to refresh it.
+  build time; CI rebuilds it on every deploy.
 
-**History:** Firebase Hosting (`bigo-portfolio`) was the previous deploy; its
-workflow (`firebase-deploy.yml`) and config (`firebase.json` / `.firebaserc`)
-were removed 2026-06-20 in favor of Netlify (part of the GCP exodus).
+> ⚠️ Verify the live host with DNS, not docs: `dig +short jeremylongshore.com`
+> → `199.36.158.100` = Firebase. (2026-06-20: a redesign was briefly mis-shipped
+> on the assumption Netlify was canonical — it is not.)
+>
+> **Planned (GCP exodus):** migrating the apex to Netlify is a candidate but is
+> NOT done — it needs a deliberate Porkbun DNS cutover + Netlify domain/SSL setup
+> with rollback. Until executed, Firebase is production.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JeremyLongshore.com
 
-[![Netlify](https://img.shields.io/badge/Netlify-deployed-00C7B7?logo=netlify&logoColor=white)](https://www.netlify.com/)
+[![Firebase Hosting](https://img.shields.io/badge/Firebase-Hosting-FFCA28?logo=firebase)](https://firebase.google.com/products/hosting)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 ![Version](https://img.shields.io/badge/version-v2.22.0-blue)
 
@@ -20,7 +20,7 @@ themes/default/         # Liquid template + CSS + Font Awesome
   styles.css            # Site styling
 plugins/                # Ruby plugins for dynamic data
   GithubRepoStarsCountPlugin.rb  # Fetches GitHub star counts
-_output/                # Generated static site (committed; served by Netlify)
+_output/                # Generated static site (committed; deployed to Firebase)
 ```
 
 **Build flow:** `config.yml` → plugins fetch data → Liquid renders `themes/default/` → `_output/`
@@ -37,24 +37,27 @@ cd _output && python -m http.server 8000
 
 ## Deployment
 
-**Netlify** hosts the live site, wired via the Netlify GitHub app (no workflow in
-this repo). Netlify serves the committed `_output/` directly — `netlify.toml` sets
-`publish = "_output"` with no build command, so whatever `_output/` you commit is
-what ships.
+**Firebase Hosting** (project `bigo-portfolio`) serves the live domain. The apex
+`jeremylongshore.com` and `www` both resolve to Firebase (`199.36.158.100`).
 
-- Push to `main` → production deploy.
-- Every PR gets a deploy preview at `deploy-preview-<N>--jeremylongshore.netlify.app`.
-- Build-time data (stars, contributions, RSS) is baked into `_output/` at commit
-  time. To refresh it, rebuild and commit:
+On push to `main`, `.github/workflows/firebase-deploy.yml`:
+1. Checks out + sets up Ruby 3.2
+2. Builds with `bundle exec ruby scaffold.rb` (`GITHUB_TOKEN` in env so the
+   stars/contributions plugins fetch live)
+3. Authenticates to GCP via Workload Identity Federation (no service-account keys)
+4. Runs `firebase deploy --only hosting --project bigo-portfolio`
+
+**Manual deploy:**
 
 ```bash
-GITHUB_TOKEN=$(gh auth token) bash build.sh   # contributions plugin needs a token
-git add _output/ && git commit -m "chore: rebuild _output"
+GITHUB_TOKEN=$(gh auth token) bash build.sh
+firebase deploy --only hosting --project bigo-portfolio
 ```
 
-> Firebase Hosting (`bigo-portfolio`) was the previous deploy; its workflow and
-> config (`firebase-deploy.yml`, `firebase.json`, `.firebaserc`) were removed
-> 2026-06-20 in favor of Netlify.
+**Netlify is preview-only** — the Netlify GitHub app builds a deploy preview per
+PR (`deploy-preview-<N>--jeremylongshore.netlify.app`); it does **not** serve the
+live domain. Verify the host with `dig +short jeremylongshore.com`, not docs.
+Migrating the apex to Netlify (GCP exodus) is a candidate but not yet done.
 
 ## Configuration
 
@@ -90,8 +93,8 @@ Automated via GitHub Actions on push to `main`:
 ## Tech Stack
 
 - **Generator:** [Linkyee](https://github.com/username/linkyee) (Ruby + Liquid)
-- **Hosting:** Netlify (serves committed `_output/`)
-- **CI/CD:** Netlify GitHub app (deploys) + GitHub Actions `release.yml` (versioning)
+- **Hosting:** Firebase Hosting (`bigo-portfolio`)
+- **CI/CD:** GitHub Actions — `firebase-deploy.yml` (deploy via WIF) + `release.yml` (versioning); Netlify GitHub app for PR previews only
 - **Icons:** Font Awesome Free
 - **Analytics:** Google Analytics 4 + self-hosted Umami
 
@@ -101,8 +104,10 @@ Automated via GitHub Actions on push to `main`:
 |------|---------|
 | `config.yml` | All site content - single source of truth |
 | `data/projects.yml` | Project listings with metadata |
-| `_output/` | Generated site (committed; served by Netlify) |
-| `netlify.toml` | Netlify config (publish dir, redirects) |
+| `_output/` | Generated site (committed; deployed to Firebase) |
+| `firebase.json` | Firebase hosting config |
+| `.firebaserc` | Firebase project binding |
+| `netlify.toml` | Netlify config (PR deploy previews only) |
 
 **Rules:**
 - Never edit `_output/` manually - regenerated on every build

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,20 @@
+{
+  "hosting": {
+    "public": "_output",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "headers": [
+      {
+        "source": "**/*.@(jpg|jpeg|gif|png|svg|webp|ico)",
+        "headers": [{"key": "Cache-Control", "value": "max-age=31536000"}]
+      },
+      {
+        "source": "**/*.@(css|js)",
+        "headers": [{"key": "Cache-Control", "value": "max-age=31536000"}]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Why

PR #9 assumed **Netlify** was the production host and removed the Firebase deploy. That was wrong — `dig +short jeremylongshore.com` → `199.36.158.100` (**Firebase Hosting**, `bigo-portfolio`). Netlify is connected for **PR previews only**. Deleting `firebase-deploy.yml` meant the merge never reached the live domain.

## Fix
- Restore `.github/workflows/firebase-deploy.yml` + `firebase.json` + `.firebaserc` → re-establishes CI deploy to the live host.
- Correct `CLAUDE.md` + `README.md`: Firebase = production (WIF deploy on push to `main`), Netlify = preview-only. Added a **'verify host via DNS, not docs'** guardrail to prevent recurrence.
- gitignore `.firebase/` deploy cache.

## Live status
The editorial redesign is **already live** on jeremylongshore.com — corrected out-of-band via a manual `firebase deploy` while diagnosing. This PR restores the *automated* path so future merges deploy correctly.

## Out of scope (deliberately)
Migrating the apex to Netlify (GCP exodus) is a real candidate but is a deliberate DNS cutover with rollback — not bundled into a hotfix.