### PR TITLE
docs(ops): point VPS authority to Intent OS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ name: Deploy jeremylongshore.com to VPS
 # -> Caddy file_server -> /healthz smoke check.
 #
 # Replaces the old Firebase deploy (removed). Onboarded per
-# intentsolutions-vps-runbook/docs/onboard-new-repo-deploy.md (static variant).
+# intent-solutions-io/intent-os/ops/deploy (static variant; D90).
 
 on:
   push:


### PR DESCRIPTION
Cuts active workflow and operator references over to the D90 Intent OS authority. Historical evidence references are preserved. No runtime, credential, schedule, or deployment behavior changes.