### PR TITLE
docs(footer): correct star count to canonical persona value (1,300+ -> 2,500+)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -74,7 +74,7 @@ contact_url: "https://intentsolutions.io/contact"
 
 # Footer text
 footer: >
-    Claude Code Plugins creator (1,300+ stars). Marine. <a href="https://www.citadel.edu" target="_blank">Citadel</a> grad. 20 years ops → self-taught dev → AI architect. I build what I sell.
+    Claude Code Plugins creator (2,500+ stars). Marine. <a href="https://www.citadel.edu" target="_blank">Citadel</a> grad. 20 years ops → self-taught dev → AI architect. I build what I sell.
 
 # Footer copyright message
 copyright: >


### PR DESCRIPTION
## What
Footer said `1,300+ stars` for claude-code-plugins. Live is **2,519** (`gh`, 2026-07-16). Updated to the canonical claim format: `2,500+ stars`.

## Why
Thread C follow-up. This footer was the most stale of the four drifting star-count copies (1,300 / 2,000+ / 2,100+ / 2,519 across four homes). De-drifts jeremylongshore.com to the new canonical persona source of truth (`intent-os/persona/master.md`).

## Refs
Single-line config change, no build impact. Companion to intent-os#142 (persona SoT) and the startaitools about.md correction.

- Jeremy Longshore
intentsolutions.io