### PR TITLE
docs(projects): rename QMD Team Intent KB entry to Bob's Big Brain Registrar

### DIFF
--- a/_output/index.html
+++ b/_output/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jeremy Longshore - I Make Teams AI-Native</title>
-  <meta name="last-modified" content="2026-06-19T23:11:06-0600">
+  <meta name="last-modified" content="2026-07-19T14:55:17-0600">
   <meta name="theme-color" content="#faf8f4">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="description" content="I build AI systems that ship and train teams to work with coding agents — Claude, Codex, Gemini, whatever moves the needle. 20+ years ops, self-taught dev, 60+ repos with real GitHub stars." />
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=2026-06-19T23:11:06-0600" />
+  <link rel="stylesheet" href="./styles.css?v=2026-07-19T14:55:17-0600" />
 </head>
 <body>
   <div class="container">
@@ -105,7 +105,7 @@
             
               
               
-                <span class="badge stars">2397 Stars</span>
+                <span class="badge stars">2530 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -137,7 +137,7 @@
             
               
               
-                <span class="badge stars">40 Stars</span>
+                <span class="badge stars">48 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -169,7 +169,7 @@
             
               
               
-                <span class="badge stars">31 Stars</span>
+                <span class="badge stars">35 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -190,38 +190,6 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="qmd-team-intent-kb">
-        <div class="link-row" onclick="toggleExpand('qmd-team-intent-kb')">
-          <div class="link-icon"><i class="fa-solid fa-book"></i></div>
-          <div class="link-text">
-            <span class="link-title">QMD Team Intent KB</span>
-            <span class="link-desc">Governed team memory platform for Claude Code</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-                <span class="badge stars">11 Stars</span>
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-qmd-team-intent-kb">
-          <p class="expand-desc">A governed team memory platform for Claude Code powered by QMD. Enables teams to build, query, and maintain a shared knowledge base with access controls, audit trails, and structured memory retrieval across Claude Code sessions.</p>
-          
-          <ul class="expand-list">
-            <li>Shared team knowledge base for Claude Code</li><li>Governed memory with access controls</li><li>Cross-session context retrieval</li><li>Audit trails for team knowledge changes</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">TypeScript</span><span class="tag tech">QMD</span>
-            <span class="tag agent">Claude Code</span>
-          </div>
-          <a href="https://github.com/jeremylongshore/qmd-team-intent-kb" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
       <div class="link-item" data-id="cad-dxf-agent">
         <div class="link-row" onclick="toggleExpand('cad-dxf-agent')">
           <div class="link-icon"><i class="fa-solid fa-compass-drafting"></i></div>
@@ -233,7 +201,7 @@
             
               
               
-                <span class="badge stars">9 Stars</span>
+                <span class="badge stars">13 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -254,6 +222,38 @@
         </div>
       </div>
       
+      <div class="link-item" data-id="bobs-big-brain-registrar">
+        <div class="link-row" onclick="toggleExpand('bobs-big-brain-registrar')">
+          <div class="link-icon"><i class="fa-solid fa-book"></i></div>
+          <div class="link-text">
+            <span class="link-title">Bob's Big Brain Registrar</span>
+            <span class="link-desc">The team's memory keeper — admits by code, keeps tamper-evident receipts</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">12 Stars</span>
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-bobs-big-brain-registrar">
+          <p class="expand-desc">Bob's Big Brain Registrar (formerly QMD Team Intent KB) — the team's memory keeper. A governed team memory platform for Claude Code: admits knowledge by deterministic code, keeps tamper-evident receipts, and serves structured memory retrieval with audit trails across Claude Code sessions.</p>
+          
+          <ul class="expand-list">
+            <li>Shared team knowledge base for Claude Code</li><li>Governed memory with access controls</li><li>Cross-session context retrieval</li><li>Audit trails for team knowledge changes</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">TypeScript</span><span class="tag tech">QMD</span>
+            <span class="tag agent">Claude Code</span>
+          </div>
+          <a href="https://github.com/jeremylongshore/bobs-big-brain-registrar" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
       <div class="link-item" data-id="startaitools">
         <div class="link-row" onclick="toggleExpand('startaitools')">
           <div class="link-icon"><i class="fa-solid fa-robot"></i></div>
@@ -265,7 +265,7 @@
             
               
               
-                <span class="badge stars">9 Stars</span>
+                <span class="badge stars">10 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -297,7 +297,7 @@
             
               
               
-                <span class="badge stars">8 Stars</span>
+                <span class="badge stars">9 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -361,7 +361,7 @@
             
               
               
-                <span class="badge stars">2 Stars</span>
+                <span class="badge stars">3 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -393,8 +393,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -415,6 +414,38 @@
         </div>
       </div>
       
+      <div class="link-item" data-id="costplusdb">
+        <div class="link-row" onclick="toggleExpand('costplusdb')">
+          <div class="link-icon"><i class="fa-solid fa-database"></i></div>
+          <div class="link-text">
+            <span class="link-title">CostPlusDB</span>
+            <span class="link-desc">Reference build — transparent Postgres hosting (infra cost + 25%) on GCP</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">2 Stars</span>
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-costplusdb">
+          <p class="expand-desc">A demonstration build exploring a transparent PostgreSQL-hosting model: infrastructure cost plus a flat 25% margin, no hidden fees or vendor lock-in. Architected on GCP Compute with Terraform-managed infrastructure, automated backups, point-in-time recovery, connection pooling, and Prometheus monitoring, plus published benchmarks against AWS RDS and Cloud SQL. The hosted service has been retired; the full implementation is public on GitHub as a portfolio reference.</p>
+          
+          <ul class="expand-list">
+            <li>Reference architecture for transparent, cost-plus database hosting</li><li>Terraform-managed GCP Compute provisioning</li><li>Automated backups and point-in-time recovery patterns</li><li>Benchmarking methodology vs. managed cloud databases</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">PostgreSQL</span><span class="tag tech">GCP Compute</span><span class="tag tech">Terraform</span><span class="tag tech">Prometheus</span>
+            
+          </div>
+          <a href="https://github.com/jeremylongshore/cost-plus-db" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
       <div class="link-item" data-id="irsb">
         <div class="link-row" onclick="toggleExpand('irsb')">
           <div class="link-icon"><i class="fa-brands fa-ethereum"></i></div>
@@ -426,8 +457,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -459,8 +489,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -492,8 +521,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -525,8 +553,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -868,7 +895,7 @@
             
               
               
-                <span class="badge stars">27 Stars</span>
+                <span class="badge stars">29 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -893,28 +920,28 @@
         <div class="link-row" onclick="toggleExpand('bobs-brain')">
           <div class="link-icon"><i class="fa-solid fa-brain"></i></div>
           <div class="link-text">
-            <span class="link-title">Bob's Brain</span>
-            <span class="link-desc">8-agent code review system for ADK pattern compliance</span>
+            <span class="link-title">IAM Bob ADK</span>
+            <span class="link-desc">Google ADK reference implementation of the Intent Agent Model</span>
           </div>
           <div class="link-badge">
             
               
               
-                <span class="badge stars">21 Stars</span>
+                <span class="badge stars">22 Stars</span>
               
             
             <span class="expand-icon">+</span>
           </div>
         </div>
         <div class="link-expand" id="expand-bobs-brain">
-          <p class="expand-desc">Multi-agent system that ensures codebase compliance with Google Agent Development Kit (ADK) patterns and best practices. Eight specialist agents review code for architecture patterns, security vulnerabilities, performance issues, and documentation gaps. Integrates with CI/CD pipelines for automated compliance checks on every commit. Essential for teams building production agents on Google Cloud.</p>
+          <p class="expand-desc">Official Google ADK and Vertex AI Agent Engine reference implementation of the Intent Agent Model. A multi-agent foreman coordinates specialists through A2A and MCP, with Vertex Session and Memory Bank support and Google-specific hard-mode deployment contracts.</p>
           
           <ul class="expand-list">
             <li>Automated code review for ADK pattern compliance</li><li>Security vulnerability scanning for agent code</li><li>Documentation generation and gap analysis</li><li>CI/CD integration for continuous compliance</li>
           </ul>
           
           <div class="expand-tags">
-            <span class="tag tech">Python</span><span class="tag tech">Cloud Run</span><span class="tag tech">Firebase</span><span class="tag tech">GitHub Actions</span>
+            <span class="tag tech">Python</span><span class="tag tech">Google Cloud</span>
             <span class="tag agent">Google ADK</span><span class="tag agent">Vertex AI Agent Engine</span>
           </div>
           <a href="https://bobs-brain.web.app/" target="_blank" class="expand-link">Open &rarr;</a>
@@ -932,7 +959,7 @@
             
               
               
-                <span class="badge stars">10 Stars</span>
+                <span class="badge stars">11 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -964,7 +991,7 @@
             
               
               
-                <span class="badge stars">8 Stars</span>
+                <span class="badge stars">10 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -996,7 +1023,7 @@
             
               
               
-                <span class="badge stars">3 Stars</span>
+                <span class="badge stars">4 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1028,8 +1055,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1061,8 +1087,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1094,8 +1119,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1379,7 +1403,7 @@
             
               
               
-                <span class="badge stars">30 Stars</span>
+                <span class="badge stars">31 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1413,7 +1437,7 @@
             
               
               
-                <span class="badge stars">3 Stars</span>
+                <span class="badge stars">4 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1436,41 +1460,6 @@
       
       
       
-      <div class="link-item" data-id="costplusdb">
-        <div class="link-row" onclick="toggleExpand('costplusdb')">
-          <div class="link-icon"><i class="fa-solid fa-database"></i></div>
-          <div class="link-text">
-            <span class="link-title">CostPlusDB</span>
-            <span class="link-desc">Transparent Postgres: infrastructure cost + 25%, period</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-                <span class="badge stars">1 Star</span>
-                
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-costplusdb">
-          <p class="expand-desc">Transparent PostgreSQL hosting with a simple pricing model: infrastructure cost plus 25% margin. No hidden fees, no surprise bills, no vendor lock-in. Published performance benchmarks let you compare against AWS RDS, Cloud SQL, and others. Features include automated backups, point-in-time recovery, connection pooling, and performance monitoring. Built on GCP Compute Engine for reliability.</p>
-          
-          <ul class="expand-list">
-            <li>Predictable database hosting with transparent pricing</li><li>Compare performance against major cloud providers</li><li>Automated backups and disaster recovery</li><li>No vendor lock-in with standard PostgreSQL</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">PostgreSQL</span><span class="tag tech">GCP Compute</span><span class="tag tech">Terraform</span><span class="tag tech">Prometheus</span>
-            
-          </div>
-          <a href="https://costplusdb.dev" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
-      
-      
       <div class="link-item" data-id="hustlestats">
         <div class="link-row" onclick="toggleExpand('hustlestats')">
           <div class="link-icon"><i class="fa-solid fa-futbol"></i></div>
@@ -1482,8 +1471,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1517,8 +1505,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1721,7 +1708,7 @@
             
               
               
-                <span class="badge stars">6 Stars</span>
+                <span class="badge stars">8 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1761,7 +1748,7 @@
           
             
             
-              <span class="badge stars">13 Stars</span>
+              <span class="badge stars">15 Stars</span>
             
           
         </div>
@@ -1772,6 +1759,22 @@
         <div class="link-text">
           <span class="link-title">N8N Workflow Template</span>
           <span class="link-desc">Professional template for documented n8n repos</span>
+        </div>
+        <div class="link-badge">
+          
+            
+            
+              <span class="badge stars">7 Stars</span>
+            
+          
+        </div>
+      </a>
+      
+      <a href="https://jeremylongshore.github.io/gmail-drive-organizer-n8n/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-envelope-open-text"></i></div>
+        <div class="link-text">
+          <span class="link-title">Gmail Drive Organizer</span>
+          <span class="link-desc">Auto-organize Gmail attachments to Drive</span>
         </div>
         <div class="link-badge">
           
@@ -1788,22 +1791,6 @@
         <div class="link-text">
           <span class="link-title">Disposable Marketplace</span>
           <span class="link-desc">Reseller outreach and quote collection automation</span>
-        </div>
-        <div class="link-badge">
-          
-            
-            
-              <span class="badge stars">5 Stars</span>
-            
-          
-        </div>
-      </a>
-      
-      <a href="https://jeremylongshore.github.io/gmail-drive-organizer-n8n/" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-envelope-open-text"></i></div>
-        <div class="link-text">
-          <span class="link-title">Gmail Drive Organizer</span>
-          <span class="link-desc">Auto-organize Gmail attachments to Drive</span>
         </div>
         <div class="link-badge">
           
@@ -1842,73 +1829,70 @@
       </a>
       <p class="section-intro">What I'm building, breaking, and shipping — direct from the commit log.</p>
       
-      <a href="https://startaitools.com/posts/the-api-is-the-real-boundary/" target="_blank" class="link-item simple article-item">
+      <a href="https://startaitools.com/posts/a-green-recovery-drill-can-still-be-lying/" target="_blank" class="link-item simple article-item">
         <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
         <div class="link-text">
-          <span class="link-title">MCP Server Auth: The API Is the Real Boundary</span>
-          <span class="link-desc">A single shared API key is fine right up until a second person uses it.
-intent-brain — the system, repo qmd-team-intent-kb, renamed to the in...</span>
+          <span class="link-title">A Green Recovery Drill Can Still Be Lying</span>
+          <span class="link-desc">We had a backup mechanism for a SigNoz staging stack. What we did not have was a proven restore. Those are different claims, and the gap betw...</span>
         </div>
         <div class="link-badge">
-          <span class="badge article-date">Jun 13, 2026</span>
+          <span class="badge article-date">Jul 18, 2026</span>
         </div>
       </a>
       
-      <a href="https://startaitools.com/posts/cap-drop-all-broke-the-gate-socket/" target="_blank" class="link-item simple article-item">
+      <a href="https://startaitools.com/posts/let-the-model-judge-make-the-code-decide/" target="_blank" class="link-item simple article-item">
         <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
         <div class="link-text">
-          <span class="link-title">When --cap-drop ALL Broke the Gate Socket</span>
-          <span class="link-desc">The dogfood run went green. The gate had governed zero calls.
-That is the agent-governance-plane&rsquo;s entire job: run an AI coding agent i...</span>
+          <span class="link-title">Let the Model Judge. Make the Code Decide.</span>
+          <span class="link-desc">This post was written by the pipeline it describes. The transcript analyzer that runs on every build day looked at the work that produced thi...</span>
         </div>
         <div class="link-badge">
-          <span class="badge article-date">Jun 12, 2026</span>
+          <span class="badge article-date">Jul 17, 2026</span>
         </div>
       </a>
       
-      <a href="https://startaitools.com/posts/when-green-ci-proves-nothing/" target="_blank" class="link-item simple article-item">
+      <a href="https://startaitools.com/posts/copying-files-is-not-installing/" target="_blank" class="link-item simple article-item">
         <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
         <div class="link-text">
-          <span class="link-title">Green CI Proves Nothing: Why Your Tests Gate Zero Calls</span>
-          <span class="link-desc">Your test passed. It gated zero tool calls. It proved nothing.
-What the Dogfood Had to Prove
-The agent-governance-plane (AGP) is a Slack-nati...</span>
+          <span class="link-title">Copying Files Is Not Installing</span>
+          <span class="link-desc">A marketplace install copies your plugin&rsquo;s files into place. It does not run npm install in them. Those are two different operations, a...</span>
         </div>
         <div class="link-badge">
-          <span class="badge article-date">Jun 11, 2026</span>
+          <span class="badge article-date">Jul 16, 2026</span>
         </div>
       </a>
       
-      <a href="https://startaitools.com/posts/honor-the-gate-when-the-verdict-is-inconvenient/" target="_blank" class="link-item simple article-item">
+      <a href="https://startaitools.com/posts/producer-fallback-when-claude-hits-weekly-limit/" target="_blank" class="link-item simple article-item">
         <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
         <div class="link-text">
-          <span class="link-title">Honor the Gate When the Verdict Is Inconvenient</span>
-          <span class="link-desc">On June 10, 2026, two completely unrelated systems hit quality gates that came back the wrong way. Neither system rationalized the verdict. B...</span>
+          <span class="link-title">Producer Fallback: When Claude Hits the Weekly Limit, the Pipeline Still Ships</span>
+          <span class="link-desc">A daily content pipeline that dies because one model returns a rate-limit error is measuring the wrong success criterion. The job is not &ldq...</span>
         </div>
         <div class="link-badge">
-          <span class="badge article-date">Jun 10, 2026</span>
+          <span class="badge article-date">Jul 15, 2026</span>
         </div>
       </a>
       
-      <a href="https://startaitools.com/posts/making-agents-reliable-on-real-device-clouds/" target="_blank" class="link-item simple article-item">
+      <a href="https://startaitools.com/posts/exit-0-is-not-success/" target="_blank" class="link-item simple article-item">
         <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
         <div class="link-text">
-          <span class="link-title">Making Agents Reliable on Real-Device Clouds</span>
-          <span class="link-desc">Canonical home: This post first appeared on Kobiton&rsquo;s blog at kobiton.com/blog/make-agents-reliable-on-real-cloud-devices. This page mi...</span>
+          <span class="link-title">Exit 0 Is Not Success: Automation Assurance That Verifies Outcomes</span>
+          <span class="link-desc">A cron that exits zero and produces nothing is not healthy. It is a silent failure wearing a green badge.
+That distinction drove most of 2026...</span>
         </div>
         <div class="link-badge">
-          <span class="badge article-date">Jun 09, 2026</span>
+          <span class="badge article-date">Jul 14, 2026</span>
         </div>
       </a>
       
-      <a href="https://startaitools.com/posts/stop-crying-wolf-3-strike-uptime-monitor-gate/" target="_blank" class="link-item simple article-item">
+      <a href="https://startaitools.com/posts/empty-is-not-clean/" target="_blank" class="link-item simple article-item">
         <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
         <div class="link-text">
-          <span class="link-title">Stop Crying Wolf: A 3-Strike Gate for Uptime Monitors</span>
-          <span class="link-desc">The uptime monitor for scorecardecho.com had been screaming since April 30th. 101 state-changes logged. Roughly 70% of them were sub-60-secon...</span>
+          <span class="link-title">Empty Is Not Clean: Five Fail-Open Bugs in an AI Agent</span>
+          <span class="link-desc">A policy said deny anything under /etc. A Bash call read /etc/shadow and came back {allow, rule: 'trust-bash'}. No human in the loop. The den...</span>
         </div>
         <div class="link-badge">
-          <span class="badge article-date">Jun 08, 2026</span>
+          <span class="badge article-date">Jul 13, 2026</span>
         </div>
       </a>
       
@@ -1970,7 +1954,7 @@ The agent-governance-plane (AGP) is a Slack-nati...</span>
     </nav>
 
     <footer>
-      <p>Claude Code Plugins creator (1,300+ stars). Marine. <a href="https://www.citadel.edu" target="_blank">Citadel</a> grad. 20 years ops → self-taught dev → AI architect. I build what I sell.
+      <p>Claude Code Plugins creator (2,500+ stars). Marine. <a href="https://www.citadel.edu" target="_blank">Citadel</a> grad. 20 years ops → self-taught dev → AI architect. I build what I sell.
 </p>
       <p class="copyright">&copy; 2026 <a href="https://jeremylongshore.com" target="_blank">Jeremy Longshore</a> | <a href="https://intentsolutions.io" target="_blank">Intent Solutions</a> | <a href="./privacy.html">Privacy</a> | <a href="./terms.html">Terms</a>
 </p>

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -680,14 +680,14 @@ personal_repos:
     tech_stack: ["Python", "Creative Writing"]
     agent_framework: []
 
-  - id: qmd-team-intent-kb
-    title: "QMD Team Intent KB"
-    url: "https://github.com/jeremylongshore/qmd-team-intent-kb"
+  - id: bobs-big-brain-registrar
+    title: "Bob's Big Brain Registrar"
+    url: "https://github.com/jeremylongshore/bobs-big-brain-registrar"
     icon: "fa-solid fa-book"
-    github_repo: "jeremylongshore/qmd-team-intent-kb"
+    github_repo: "jeremylongshore/bobs-big-brain-registrar"
     visibility: public
-    purpose_short: "Governed team memory platform for Claude Code"
-    purpose_long: "A governed team memory platform for Claude Code powered by QMD. Enables teams to build, query, and maintain a shared knowledge base with access controls, audit trails, and structured memory retrieval across Claude Code sessions."
+    purpose_short: "The team's memory keeper — admits by code, keeps tamper-evident receipts"
+    purpose_long: "Bob's Big Brain Registrar (formerly QMD Team Intent KB) — the team's memory keeper. A governed team memory platform for Claude Code: admits knowledge by deterministic code, keeps tamper-evident receipts, and serves structured memory retrieval with audit trails across Claude Code sessions."
     use_cases:
       - "Shared team knowledge base for Claude Code"
       - "Governed memory with access controls"


### PR DESCRIPTION
## What

- `data/projects.yml`: the govern-engine entry's id, title, GitHub URL, `github_repo`, and descriptions now use `jeremylongshore/bobs-big-brain-registrar` (renamed today from `qmd-team-intent-kb`); `purpose_long` keeps a "formerly QMD Team Intent KB" note.
- `_output/index.html`: rebuilt via `bash build.sh` per the repo's contract (committed output is what `deploy.yml` ships). The rebuild also refreshed live-fetched GitHub star counts, which accounts for the extra churn in the output diff.

## Why

The GitHub repo was renamed 2026-07-19 to its public Bob's Big Brain product name; the site card should link and label the current name. Chose renaming the entry in place over adding a second card because the site lists one card per repo (GitHub redirects the old slug regardless). No `intentional-cognition-os` entry exists in `projects.yml`, so only the Registrar card changed.

## Verification

`bash build.sh` completed clean; `rg` for the old slugs in `_output/index.html` returns zero hits and `bobs-big-brain-registrar` renders 4 times. Content-only change — no template, plugin, or deploy-workflow edits.

## Risk / rollback

Static-content change; deploy is the standard push-to-main workflow. Revert the single commit to roll back.

## Refs

Part of the 2026-07-19 Bob's Big Brain engine-repo rename sweep.