### PR TITLE
feat(profile): add Claude Partner Network certification card to profile header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Personal landing page for Jeremy Longshore built with **Linkyee** (Ruby-based static site generator). Single-page design featuring project links, social profiles, and dynamic GitHub star counts.
 
 **Live:** https://jeremylongshore.com
-**Deployment:** Firebase Hosting via GitHub Actions (builds on push to main)
+**Deployment:** Contabo VPS `intentsolutions` (`167.86.106.29`, Caddy). Verified via `dig +short jeremylongshore.com` 2026-07-16. Migrated off Firebase Hosting + Netlify on 2026-06-20. **NOT Firebase, NOT Netlify** — the repo still carries a stale `firebase-deploy.yml`/`netlify.toml` from the old hosts. Confirm the current pipeline against `~/.claude/CLAUDE.md` § "Cloud Platform" and the VPS runbook before touching deploy.
 
 ## Commands
 
@@ -72,11 +72,10 @@ text: "Project <span class='link-button-text'>({{vars.GithubRepoStarsCountPlugin
 
 ## Deployment
 
-- **Host:** Firebase Hosting (project: `bigo-portfolio`)
-- **Trigger:** Push to `main` branch
-- **Workflow:** `.github/workflows/firebase-deploy.yml`
-- **Auth:** Workload Identity Federation (no service account keys)
-- **Caching:** 1-year cache for images, CSS, JS
+- **Host:** Contabo VPS `intentsolutions` (`167.86.106.29`), served by Caddy. `dig`-verified 2026-07-16.
+- **History:** Migrated 2026-06-20 off **Firebase Hosting** (project `bigo-portfolio`) and Netlify. The old Firebase note (WIF auth, 1-year caching, push-to-`main` trigger) described the retired host, not the live one.
+- **Stale artifacts:** `.github/workflows/firebase-deploy.yml` and `netlify.toml` remain in the repo from the prior hosts — they do not reflect the live pipeline. Do not treat them as authoritative.
+- **Source of truth for the live pipeline:** `~/.claude/CLAUDE.md` § "Cloud Platform" + the VPS runbook (`~/000-projects/intentsolutions-vps-runbook/`). Verify the host with `dig`, not this file.
 
 ## Dependencies
 

--- a/_output/index.html
+++ b/_output/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jeremy Longshore - I Make Teams AI-Native</title>
-  <meta name="last-modified" content="2026-03-06T13:25:00-0600">
+  <meta name="last-modified" content="2026-03-25T00:49:08-0500">
   <meta name="theme-color" content="#FFFFFF">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="description" content="I build AI systems that ship and train teams to work with coding agents — Claude, Codex, Gemini, whatever moves the needle. 20+ years ops, self-taught dev, 60+ repos with real GitHub stars." />
@@ -15,7 +15,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="./images/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="./images/favicons/favicon-32x32.png">
   <link rel="shortcut icon" href="./images/favicons/favicon.ico">
-  <link rel="stylesheet" href="./styles.css?v=2026-03-06T13:25:00-0600" />
+  <link rel="stylesheet" href="./styles.css?v=2026-03-25T00:49:08-0500" />
 </head>
 <body>
   <div class="container">
@@ -92,7 +92,7 @@
             
               
               
-                <span class="badge stars">1530 Stars</span>
+                <span class="badge stars">1708 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -124,7 +124,7 @@
             
               
               
-                <span class="badge stars">7 Stars</span>
+                <span class="badge stars">11 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -156,7 +156,7 @@
             
               
               
-                <span class="badge stars">7 Stars</span>
+                <span class="badge stars">8 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -206,6 +206,38 @@
             
           </div>
           <a href="https://startaitools.com" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
+      <div class="link-item" data-id="hybrid-ai-stack">
+        <div class="link-row" onclick="toggleExpand('hybrid-ai-stack')">
+          <div class="link-icon"><i class="fa-solid fa-layer-group"></i></div>
+          <div class="link-text">
+            <span class="link-title">Hybrid AI Stack</span>
+            <span class="link-desc">Reference architecture: Vertex AI + Firebase + Cloud Run</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">2 Stars</span>
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-hybrid-ai-stack">
+          <p class="expand-desc">Reference architecture for building hybrid AI systems on Google Cloud. Combines Vertex AI, Firebase, and Cloud Run for production-grade AI applications.</p>
+          
+          <ul class="expand-list">
+            <li>Production AI architecture patterns</li><li>Google Cloud AI integrations</li><li>Hybrid cloud + AI deployments</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Google Cloud</span><span class="tag tech">Vertex AI</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Run</span>
+            <span class="tag agent">Vertex AI</span>
+          </div>
+          <a href="https://github.com/jeremylongshore/Hybrid-ai-stack-intent-solutions" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -274,12 +306,12 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="hybrid-ai-stack">
-        <div class="link-row" onclick="toggleExpand('hybrid-ai-stack')">
-          <div class="link-icon"><i class="fa-solid fa-layer-group"></i></div>
+      <div class="link-item" data-id="irsb">
+        <div class="link-row" onclick="toggleExpand('irsb')">
+          <div class="link-icon"><i class="fa-brands fa-ethereum"></i></div>
           <div class="link-text">
-            <span class="link-title">Hybrid AI Stack</span>
-            <span class="link-desc">Reference architecture: Vertex AI + Firebase + Cloud Run</span>
+            <span class="link-title">IRSB</span>
+            <span class="link-desc">EIP-7702 spend limits + on-chain receipts for intent accountability</span>
           </div>
           <div class="link-badge">
             
@@ -292,18 +324,18 @@
             <span class="expand-icon">+</span>
           </div>
         </div>
-        <div class="link-expand" id="expand-hybrid-ai-stack">
-          <p class="expand-desc">Reference architecture for building hybrid AI systems on Google Cloud. Combines Vertex AI, Firebase, and Cloud Run for production-grade AI applications.</p>
+        <div class="link-expand" id="expand-irsb">
+          <p class="expand-desc">Intent Receipts & Solver Bonds (IRSB) - Consolidated monorepo containing the Ethereum protocol, solver, watchtower, and agent components. Features EIP-7702 spend limits, execution receipts with cryptographic proofs, dispute resolution, and automated slashing for timeouts and constraint violations. Includes watchtower service for real-time on-chain monitoring and violation detection.</p>
           
           <ul class="expand-list">
-            <li>Production AI architecture patterns</li><li>Google Cloud AI integrations</li><li>Hybrid cloud + AI deployments</li>
+            <li>On-chain intent receipts with cryptographic proofs</li><li>EIP-7702 spend limits and execution receipts</li><li>Automated dispute resolution and slashing</li><li>Real-time watchtower monitoring of solver behavior</li>
           </ul>
           
           <div class="expand-tags">
-            <span class="tag tech">Google Cloud</span><span class="tag tech">Vertex AI</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Run</span>
-            <span class="tag agent">Vertex AI</span>
+            <span class="tag tech">Solidity</span><span class="tag tech">Foundry</span><span class="tag tech">Ethereum</span><span class="tag tech">ERC-7683</span>
+            
           </div>
-          <a href="https://github.com/jeremylongshore/Hybrid-ai-stack-intent-solutions" target="_blank" class="expand-link">Open &rarr;</a>
+          <a href="https://irsb-protocol.web.app" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -370,36 +402,6 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="irsb">
-        <div class="link-row" onclick="toggleExpand('irsb')">
-          <div class="link-icon"><i class="fa-brands fa-ethereum"></i></div>
-          <div class="link-text">
-            <span class="link-title">IRSB</span>
-            <span class="link-desc">EIP-7702 spend limits + on-chain receipts for intent accountability</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-irsb">
-          <p class="expand-desc">Intent Receipts & Solver Bonds (IRSB) - Consolidated monorepo containing the Ethereum protocol, solver, watchtower, and agent components. Features EIP-7702 spend limits, execution receipts with cryptographic proofs, dispute resolution, and automated slashing for timeouts and constraint violations. Includes watchtower service for real-time on-chain monitoring and violation detection.</p>
-          
-          <ul class="expand-list">
-            <li>On-chain intent receipts with cryptographic proofs</li><li>EIP-7702 spend limits and execution receipts</li><li>Automated dispute resolution and slashing</li><li>Real-time watchtower monitoring of solver behavior</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Solidity</span><span class="tag tech">Foundry</span><span class="tag tech">Ethereum</span><span class="tag tech">ERC-7683</span>
-            
-          </div>
-          <a href="https://irsb-protocol.web.app" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
       <div class="link-item" data-id="lumera-agent-memory">
         <div class="link-row" onclick="toggleExpand('lumera-agent-memory')">
           <div class="link-icon"><i class="fa-solid fa-brain"></i></div>
@@ -451,7 +453,7 @@
             
               
               
-                <span class="badge stars">25 Stars</span>
+                <span class="badge stars">26 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -483,7 +485,7 @@
             
               
               
-                <span class="badge stars">16 Stars</span>
+                <span class="badge stars">19 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -547,7 +549,7 @@
             
               
               
-                <span class="badge stars">5 Stars</span>
+                <span class="badge stars">6 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -600,6 +602,38 @@
         </div>
       </div>
       
+      <div class="link-item" data-id="executive-intent">
+        <div class="link-row" onclick="toggleExpand('executive-intent')">
+          <div class="link-icon"><i class="fa-solid fa-shield-check"></i></div>
+          <div class="link-text">
+            <span class="link-title">Executive Intent</span>
+            <span class="link-desc">DLP-enforced Gmail/Calendar intelligence with audit receipts</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">2 Stars</span>
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-executive-intent">
+          <p class="expand-desc">Enterprise security pipeline that transforms Gmail and Calendar data into a governed, DLP-screened knowledge base. Ingests email and calendar metadata through OAuth, applies Nightfall DLP enforcement (allow/redact/quarantine), indexes content with pgvector embeddings, and enables semantic retrieval with documented provenance. Every query returns audit receipts tied to build and deploy pipelines.</p>
+          
+          <ul class="expand-list">
+            <li>Secure executive email intelligence with DLP compliance</li><li>Semantic search across email and calendar with audit trails</li><li>Evidence bundles for compliance and legal discovery</li><li>Real-time DLP enforcement on sensitive communications</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Next.js</span><span class="tag tech">Supabase</span><span class="tag tech">pgvector</span><span class="tag tech">Inngest</span>
+            <span class="tag agent">Nightfall DLP</span><span class="tag agent">OpenAI Embeddings</span>
+          </div>
+          <a href="https://executive-intent.web.app" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
       <div class="link-item" data-id="bounties">
         <div class="link-row" onclick="toggleExpand('bounties')">
           <div class="link-icon"><i class="fa-solid fa-bullseye"></i></div>
@@ -633,12 +667,12 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="executive-intent">
-        <div class="link-row" onclick="toggleExpand('executive-intent')">
-          <div class="link-icon"><i class="fa-solid fa-shield-check"></i></div>
+      <div class="link-item" data-id="diagnosticpro">
+        <div class="link-row" onclick="toggleExpand('diagnosticpro')">
+          <div class="link-icon"><i class="fa-solid fa-wrench"></i></div>
           <div class="link-text">
-            <span class="link-title">Executive Intent</span>
-            <span class="link-desc">DLP-enforced Gmail/Calendar intelligence with audit receipts</span>
+            <span class="link-title">DiagnosticPro</span>
+            <span class="link-desc">Photo-to-diagnosis: upload a pic, get a repair plan</span>
           </div>
           <div class="link-badge">
             
@@ -651,18 +685,18 @@
             <span class="expand-icon">+</span>
           </div>
         </div>
-        <div class="link-expand" id="expand-executive-intent">
-          <p class="expand-desc">Enterprise security pipeline that transforms Gmail and Calendar data into a governed, DLP-screened knowledge base. Ingests email and calendar metadata through OAuth, applies Nightfall DLP enforcement (allow/redact/quarantine), indexes content with pgvector embeddings, and enables semantic retrieval with documented provenance. Every query returns audit receipts tied to build and deploy pipelines.</p>
+        <div class="link-expand" id="expand-diagnosticpro">
+          <p class="expand-desc">Consumer-facing AI diagnostic platform that helps users troubleshoot equipment issues using Vertex AI Gemini. Upload photos or describe symptoms, and get instant AI-powered diagnosis with repair cost estimates and step-by-step fix instructions. Covers vehicles, appliances, HVAC, and more. Pay-per-diagnosis model at $4.99 makes professional-grade diagnostics accessible to everyone.</p>
           
           <ul class="expand-list">
-            <li>Secure executive email intelligence with DLP compliance</li><li>Semantic search across email and calendar with audit trails</li><li>Evidence bundles for compliance and legal discovery</li><li>Real-time DLP enforcement on sensitive communications</li>
+            <li>Diagnose vehicle issues from symptoms or photos</li><li>Get accurate repair cost estimates before visiting a shop</li><li>Follow AI-guided troubleshooting steps</li><li>Track maintenance history and upcoming service needs</li>
           </ul>
           
           <div class="expand-tags">
-            <span class="tag tech">Next.js</span><span class="tag tech">Supabase</span><span class="tag tech">pgvector</span><span class="tag tech">Inngest</span>
-            <span class="tag agent">Nightfall DLP</span><span class="tag agent">OpenAI Embeddings</span>
+            <span class="tag tech">React</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Functions</span><span class="tag tech">Firestore</span>
+            <span class="tag agent">Vertex AI Gemini</span>
           </div>
-          <a href="https://executive-intent.web.app" target="_blank" class="expand-link">Open &rarr;</a>
+          <a href="https://diagnosticpro.io" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -729,36 +763,6 @@
             <span class="tag agent">MCP Servers</span>
           </div>
           <a href="https://github.com/intent-solutions-io/intent-mail" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
-      <div class="link-item" data-id="diagnosticpro">
-        <div class="link-row" onclick="toggleExpand('diagnosticpro')">
-          <div class="link-icon"><i class="fa-solid fa-wrench"></i></div>
-          <div class="link-text">
-            <span class="link-title">DiagnosticPro</span>
-            <span class="link-desc">Photo-to-diagnosis: upload a pic, get a repair plan</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-diagnosticpro">
-          <p class="expand-desc">Consumer-facing AI diagnostic platform that helps users troubleshoot equipment issues using Vertex AI Gemini. Upload photos or describe symptoms, and get instant AI-powered diagnosis with repair cost estimates and step-by-step fix instructions. Covers vehicles, appliances, HVAC, and more. Pay-per-diagnosis model at $4.99 makes professional-grade diagnostics accessible to everyone.</p>
-          
-          <ul class="expand-list">
-            <li>Diagnose vehicle issues from symptoms or photos</li><li>Get accurate repair cost estimates before visiting a shop</li><li>Follow AI-guided troubleshooting steps</li><li>Track maintenance history and upcoming service needs</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">React</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Functions</span><span class="tag tech">Firestore</span>
-            <span class="tag agent">Vertex AI Gemini</span>
-          </div>
-          <a href="https://diagnosticpro.io" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -934,7 +938,7 @@
             
               
               
-                <span class="badge stars">24 Stars</span>
+                <span class="badge stars">29 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -966,6 +970,9 @@
             
               
               
+                <span class="badge stars">1 Star</span>
+                
+              
             
             <span class="expand-icon">+</span>
           </div>
@@ -996,6 +1003,9 @@
             
               
               
+                <span class="badge stars">1 Star</span>
+                
+              
             
             <span class="expand-icon">+</span>
           </div>
@@ -1012,6 +1022,39 @@
             <span class="tag agent">Vertex AI Agent Engine</span><span class="tag agent">A2A Protocol</span>
           </div>
           <a href="https://hustlestats.io" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
+      <div class="link-item" data-id="stci">
+        <div class="link-row" onclick="toggleExpand('stci')">
+          <div class="link-icon"><i class="fa-solid fa-chart-line"></i></div>
+          <div class="link-text">
+            <span class="link-title">STCI</span>
+            <span class="link-desc">Daily LLM pricing across every major provider, free API</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">1 Star</span>
+                
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-stci">
+          <p class="expand-desc">The Standard Token Cost Index - a daily benchmark tracking LLM API pricing across OpenAI, Anthropic, Google, DeepSeek, and other providers. Historical price tracking shows cost trends over time. Free public API endpoint lets developers query current prices programmatically. Essential resource for teams optimizing AI infrastructure costs and making informed provider decisions.</p>
+          
+          <ul class="expand-list">
+            <li>Compare LLM API pricing across providers</li><li>Track historical price changes and trends</li><li>Free API endpoint for programmatic access</li><li>Optimize AI infrastructure costs</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Python</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Scheduler</span><span class="tag tech">FastAPI</span>
+            
+          </div>
+          <a href="https://inferencepriceindex.com" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -1098,36 +1141,6 @@
             <span class="tag agent">Google ADK</span><span class="tag agent">Vertex AI Agent Engine</span>
           </div>
           <a href="https://pipelinepilot-prod.web.app" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
-      <div class="link-item" data-id="stci">
-        <div class="link-row" onclick="toggleExpand('stci')">
-          <div class="link-icon"><i class="fa-solid fa-chart-line"></i></div>
-          <div class="link-text">
-            <span class="link-title">STCI</span>
-            <span class="link-desc">Daily LLM pricing across every major provider, free API</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-stci">
-          <p class="expand-desc">The Standard Token Cost Index - a daily benchmark tracking LLM API pricing across OpenAI, Anthropic, Google, DeepSeek, and other providers. Historical price tracking shows cost trends over time. Free public API endpoint lets developers query current prices programmatically. Essential resource for teams optimizing AI infrastructure costs and making informed provider decisions.</p>
-          
-          <ul class="expand-list">
-            <li>Compare LLM API pricing across providers</li><li>Track historical price changes and trends</li><li>Free API endpoint for programmatic access</li><li>Optimize AI infrastructure costs</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Python</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Scheduler</span><span class="tag tech">FastAPI</span>
-            
-          </div>
-          <a href="https://inferencepriceindex.com" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -1270,7 +1283,7 @@
           
             
             
-              <span class="badge stars">10 Stars</span>
+              <span class="badge stars">11 Stars</span>
             
           
         </div>
@@ -1355,6 +1368,106 @@
       </ul>
       <a href="https://calendar.app.google/Wqbt8EJuEh5xvvV58" target="_blank" class="cta-link">Let's talk →</a>
     </section>
+
+    
+    <section class="links blog-section">
+      <a href="https://startaitools.com/posts/" target="_blank" class="section-header">
+        <h2 class="section-label">Latest Writing</h2>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+      </a>
+      <p class="section-intro">Technical deep-dives on AI agents, plugin development, and production systems.</p>
+      
+      <a href="https://startaitools.com/posts/x-bug-triage-plugin-zero-to-v043-one-day/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">X Bug Triage Plugin: Zero to v0.4.3 in One Day</span>
+          <span class="link-desc">A brand-new MCP plugin that triages X/Twitter bug reports shipped 10 epics, 13 releases, 89 tests, and 4 extracted sub-agents.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-23</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/ninety-skills-three-packs-one-day/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Ninety Skills, Three Packs, One Day</span>
+          <span class="link-desc">Building three complete 30-skill SaaS integration packs — Sentry, Notion, and Supabase — in a single day.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-22</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/nuclear-option-day-validator-rewrite-414-plugins/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Nuclear Option Day: Validator Rewrite, 63 New Packs, 414 Plugins</span>
+          <span class="link-desc">Rewrote the universal validator from scratch to match Anthropic's 14-field spec, generated 63 SaaS packs.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-21</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/58-e2e-tests-slack-channel-launch-one-day/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">58 E2E Tests, a Slack Channel Launch, and the Auth Injection That Made It Work</span>
+          <span class="link-desc">How REST API auth plus IndexedDB injection unlocked 58 production E2E tests for cad-dxf-agent.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-20</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/governed-knowledge-two-releases-freshness-daemon/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Governed Knowledge: Two Major Releases, a Freshness Daemon, and Export Gating</span>
+          <span class="link-desc">qmd-team-intent-kb ships v0.2.0 and v0.3.0 in one day — freshness-aware search with exponential decay.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-19</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/knowledge-base-zero-to-api-lifecycle-state-machine/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Knowledge Base from Zero to API: Lifecycle State Machines and Policy Engines</span>
+          <span class="link-desc">Building a team knowledge base with lifecycle state machines, policy engines, and git-exported articles.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-18</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/content-quality-war-7-check-audit-across-340-plugins/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Content Quality War: 7-Check Audit Across 340 Plugins</span>
+          <span class="link-desc">A 7-category audit script found boilerplate openings, empty shells, reference stubs, and duplicate content.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-17</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/meta-agent-orchestration-and-the-ux-of-removing-features/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">Meta-Agent Orchestration and the UX of Removing Features</span>
+          <span class="link-desc">The oss-agent-lab ships its meta-agent capstone — one agent to orchestrate nine specialists.</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">2026-03-16</span>
+        </div>
+      </a>
+      
+      <a href="https://startaitools.com/posts/" target="_blank" class="view-all-link">View all posts →</a>
+    </section>
+    
 
     <nav class="socials">
       

--- a/_output/index.html
+++ b/_output/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jeremy Longshore - I Make Teams AI-Native</title>
-  <meta name="last-modified" content="2026-03-25T00:49:08-0500">
+  <meta name="last-modified" content="2026-07-26T19:37:23-0600">
   <meta name="theme-color" content="#FFFFFF">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="description" content="I build AI systems that ship and train teams to work with coding agents — Claude, Codex, Gemini, whatever moves the needle. 20+ years ops, self-taught dev, 60+ repos with real GitHub stars." />
@@ -15,7 +15,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="./images/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="./images/favicons/favicon-32x32.png">
   <link rel="shortcut icon" href="./images/favicons/favicon.ico">
-  <link rel="stylesheet" href="./styles.css?v=2026-03-25T00:49:08-0500" />
+  <link rel="stylesheet" href="./styles.css?v=2026-07-26T19:37:23-0600" />
 </head>
 <body>
   <div class="container">
@@ -30,6 +30,18 @@
         <span>·</span>
         <a href="https://startaitools.com" target="_blank">startaitools.com</a>
       </p>
+
+      <aside class="credly-card" aria-label="Claude Partner Network certification">
+        <div class="credly-badge">
+          <div data-iframe-width="150" data-iframe-height="270" data-share-badge-id="ddf22fb4-0aa6-46b3-a93b-0b45b509e471" data-share-badge-host="https://www.credly.com"></div>
+        </div>
+        <div class="credly-meta">
+          <div class="credly-eyebrow">Anthropic-issued</div>
+          <div class="credly-title">Claude Partner Badge &middot; Claude Code</div>
+          <p class="credly-desc">Certified through the Claude Partner Network to scope, deploy, configure, and run Claude Code activations end-to-end. Eight-course program with a scenario-based capstone.</p>
+          <a class="credly-link" href="https://www.credly.com/badges/ddf22fb4-0aa6-46b3-a93b-0b45b509e471" target="_blank" rel="noopener noreferrer">Verify on Credly &rarr;</a>
+        </div>
+      </aside>
     </header>
 
     <section class="contact-cta top">
@@ -92,7 +104,7 @@
             
               
               
-                <span class="badge stars">1708 Stars</span>
+                <span class="badge stars">2557 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -124,7 +136,7 @@
             
               
               
-                <span class="badge stars">11 Stars</span>
+                <span class="badge stars">49 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -145,38 +157,6 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="iam-local-rag">
-        <div class="link-row" onclick="toggleExpand('iam-local-rag')">
-          <div class="link-icon"><i class="fa-solid fa-database"></i></div>
-          <div class="link-text">
-            <span class="link-title">NEXUS Local RAG</span>
-            <span class="link-desc">Query private docs with AI — 100% local, zero cloud cost</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-                <span class="badge stars">8 Stars</span>
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-iam-local-rag">
-          <p class="expand-desc">Fully autonomous local AI agent for private document intelligence. Runs 100% locally with no cloud costs using Ollama for inference and LangChain for orchestration. Indexes documents into vector store for semantic retrieval while keeping all data on-premises.</p>
-          
-          <ul class="expand-list">
-            <li>Query private documents with natural language</li><li>Run AI analysis without cloud API costs</li><li>Keep sensitive data fully on-premises</li><li>Build custom knowledge bases from local files</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Python</span><span class="tag tech">LangChain</span><span class="tag tech">Ollama</span><span class="tag tech">ChromaDB</span>
-            
-          </div>
-          <a href="https://github.com/intent-solutions-io/iam-local-rag" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
       <div class="link-item" data-id="startaitools">
         <div class="link-row" onclick="toggleExpand('startaitools')">
           <div class="link-icon"><i class="fa-solid fa-robot"></i></div>
@@ -188,7 +168,7 @@
             
               
               
-                <span class="badge stars">7 Stars</span>
+                <span class="badge stars">10 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -209,6 +189,38 @@
         </div>
       </div>
       
+      <div class="link-item" data-id="iam-local-rag">
+        <div class="link-row" onclick="toggleExpand('iam-local-rag')">
+          <div class="link-icon"><i class="fa-solid fa-database"></i></div>
+          <div class="link-text">
+            <span class="link-title">NEXUS Local RAG</span>
+            <span class="link-desc">Query private docs with AI — 100% local, zero cloud cost</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">9 Stars</span>
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-iam-local-rag">
+          <p class="expand-desc">Fully autonomous local AI agent for private document intelligence. Runs 100% locally with no cloud costs using Ollama for inference and LangChain for orchestration. Indexes documents into vector store for semantic retrieval while keeping all data on-premises.</p>
+          
+          <ul class="expand-list">
+            <li>Query private documents with natural language</li><li>Run AI analysis without cloud API costs</li><li>Keep sensitive data fully on-premises</li><li>Build custom knowledge bases from local files</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Python</span><span class="tag tech">LangChain</span><span class="tag tech">Ollama</span><span class="tag tech">ChromaDB</span>
+            
+          </div>
+          <a href="https://github.com/intent-solutions-io/iam-local-rag" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
       <div class="link-item" data-id="hybrid-ai-stack">
         <div class="link-row" onclick="toggleExpand('hybrid-ai-stack')">
           <div class="link-icon"><i class="fa-solid fa-layer-group"></i></div>
@@ -220,7 +232,7 @@
             
               
               
-                <span class="badge stars">2 Stars</span>
+                <span class="badge stars">5 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -252,7 +264,7 @@
             
               
               
-                <span class="badge stars">2 Stars</span>
+                <span class="badge stars">3 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -273,39 +285,6 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="create-agent-skill-md">
-        <div class="link-row" onclick="toggleExpand('create-agent-skill-md')">
-          <div class="link-icon"><i class="fa-solid fa-wand-magic-sparkles"></i></div>
-          <div class="link-text">
-            <span class="link-title">Create Agent Skill MD</span>
-            <span class="link-desc">Scaffold, validate, and migrate Claude Code skills via CLI</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-                <span class="badge stars">1 Star</span>
-                
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-create-agent-skill-md">
-          <p class="expand-desc">Command-line tool for scaffolding and validating Claude Code agent skills. Generates compliant SKILL.md files with proper frontmatter, validates existing skills against the 2025 specification, and provides migration helpers for older skill formats.</p>
-          
-          <ul class="expand-list">
-            <li>Scaffold new skills with proper structure</li><li>Validate skills against 2025 spec</li><li>Migrate legacy skills to current format</li><li>Check skill compatibility before publish</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Go</span><span class="tag tech">CLI</span>
-            <span class="tag agent">Claude Code</span>
-          </div>
-          <a href="https://github.com/intent-solutions-io/create-agent-skill-md" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
       <div class="link-item" data-id="irsb">
         <div class="link-row" onclick="toggleExpand('irsb')">
           <div class="link-icon"><i class="fa-brands fa-ethereum"></i></div>
@@ -317,8 +296,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -350,8 +328,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -369,6 +346,36 @@
             <span class="tag agent">MCP Protocol</span>
           </div>
           <a href="https://github.com/jeremylongshore/waygate-mcp" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
+      <div class="link-item" data-id="create-agent-skill-md">
+        <div class="link-row" onclick="toggleExpand('create-agent-skill-md')">
+          <div class="link-icon"><i class="fa-solid fa-wand-magic-sparkles"></i></div>
+          <div class="link-text">
+            <span class="link-title">Create Agent Skill MD</span>
+            <span class="link-desc">Scaffold, validate, and migrate Claude Code skills via CLI</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-create-agent-skill-md">
+          <p class="expand-desc">Command-line tool for scaffolding and validating Claude Code agent skills. Generates compliant SKILL.md files with proper frontmatter, validates existing skills against the 2025 specification, and provides migration helpers for older skill formats.</p>
+          
+          <ul class="expand-list">
+            <li>Scaffold new skills with proper structure</li><li>Validate skills against 2025 spec</li><li>Migrate legacy skills to current format</li><li>Check skill compatibility before publish</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Go</span><span class="tag tech">CLI</span>
+            <span class="tag agent">Claude Code</span>
+          </div>
+          <a href="https://github.com/intent-solutions-io/create-agent-skill-md" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -453,7 +460,7 @@
             
               
               
-                <span class="badge stars">26 Stars</span>
+                <span class="badge stars">30 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -485,7 +492,7 @@
             
               
               
-                <span class="badge stars">19 Stars</span>
+                <span class="badge stars">22 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -517,7 +524,7 @@
             
               
               
-                <span class="badge stars">9 Stars</span>
+                <span class="badge stars">11 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -549,7 +556,7 @@
             
               
               
-                <span class="badge stars">6 Stars</span>
+                <span class="badge stars">10 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -570,38 +577,6 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="intent-genai-project-template">
-        <div class="link-row" onclick="toggleExpand('intent-genai-project-template')">
-          <div class="link-icon"><i class="fa-solid fa-layer-group"></i></div>
-          <div class="link-text">
-            <span class="link-title">GenAI Project Template</span>
-            <span class="link-desc">FastAPI + evals + Docker — LLM app in minutes</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-                <span class="badge stars">4 Stars</span>
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-intent-genai-project-template">
-          <p class="expand-desc">Battle-tested Python project template for building LLM applications. Includes FastAPI server, CLI interface, prompt pack management, streaming support, and evaluation framework. Preconfigured CI/CD with GitHub Actions, Docker support, and structured logging via structlog.</p>
-          
-          <ul class="expand-list">
-            <li>Bootstrap new LLM projects in minutes</li><li>Run prompt evaluations with built-in framework</li><li>Deploy via Docker with production defaults</li><li>Manage prompt versions with prompt packs</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Python</span><span class="tag tech">FastAPI</span><span class="tag tech">Docker</span><span class="tag tech">structlog</span><span class="tag tech">GitHub Actions</span>
-            
-          </div>
-          <a href="https://github.com/intent-solutions-io/intent-genai-project-template" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
       <div class="link-item" data-id="executive-intent">
         <div class="link-row" onclick="toggleExpand('executive-intent')">
           <div class="link-icon"><i class="fa-solid fa-shield-check"></i></div>
@@ -613,7 +588,7 @@
             
               
               
-                <span class="badge stars">2 Stars</span>
+                <span class="badge stars">4 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -645,8 +620,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -667,72 +641,6 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="diagnosticpro">
-        <div class="link-row" onclick="toggleExpand('diagnosticpro')">
-          <div class="link-icon"><i class="fa-solid fa-wrench"></i></div>
-          <div class="link-text">
-            <span class="link-title">DiagnosticPro</span>
-            <span class="link-desc">Photo-to-diagnosis: upload a pic, get a repair plan</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-                <span class="badge stars">1 Star</span>
-                
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-diagnosticpro">
-          <p class="expand-desc">Consumer-facing AI diagnostic platform that helps users troubleshoot equipment issues using Vertex AI Gemini. Upload photos or describe symptoms, and get instant AI-powered diagnosis with repair cost estimates and step-by-step fix instructions. Covers vehicles, appliances, HVAC, and more. Pay-per-diagnosis model at $4.99 makes professional-grade diagnostics accessible to everyone.</p>
-          
-          <ul class="expand-list">
-            <li>Diagnose vehicle issues from symptoms or photos</li><li>Get accurate repair cost estimates before visiting a shop</li><li>Follow AI-guided troubleshooting steps</li><li>Track maintenance history and upcoming service needs</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">React</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Functions</span><span class="tag tech">Firestore</span>
-            <span class="tag agent">Vertex AI Gemini</span>
-          </div>
-          <a href="https://diagnosticpro.io" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
-      <div class="link-item" data-id="intent-catalog">
-        <div class="link-row" onclick="toggleExpand('intent-catalog')">
-          <div class="link-icon"><i class="fa-solid fa-folder-tree"></i></div>
-          <div class="link-text">
-            <span class="link-title">Intent Catalog</span>
-            <span class="link-desc">Version control and discovery API for plugin ecosystems</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-                <span class="badge stars">1 Star</span>
-                
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-intent-catalog">
-          <p class="expand-desc">Centralized catalog system for managing Claude Code plugins, agent skills, and documentation assets. Provides versioning, dependency resolution, and discovery APIs. Built as the backbone for Intent Solutions' plugin ecosystem with full CRUD operations and metadata indexing.</p>
-          
-          <ul class="expand-list">
-            <li>Manage plugin versions and dependencies</li><li>Discover skills by capability or tag</li><li>Index and search documentation assets</li><li>Automate catalog updates via CI/CD</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Python</span><span class="tag tech">FastAPI</span><span class="tag tech">SQLite</span>
-            
-          </div>
-          <a href="https://github.com/intent-solutions-io/intent-catalog" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
       <div class="link-item" data-id="intentmail">
         <div class="link-row" onclick="toggleExpand('intentmail')">
           <div class="link-icon"><i class="fa-solid fa-envelope"></i></div>
@@ -744,8 +652,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -763,6 +670,36 @@
             <span class="tag agent">MCP Servers</span>
           </div>
           <a href="https://github.com/intent-solutions-io/intent-mail" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
+      <div class="link-item" data-id="diagnosticpro">
+        <div class="link-row" onclick="toggleExpand('diagnosticpro')">
+          <div class="link-icon"><i class="fa-solid fa-wrench"></i></div>
+          <div class="link-text">
+            <span class="link-title">DiagnosticPro</span>
+            <span class="link-desc">Photo-to-diagnosis: upload a pic, get a repair plan</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-diagnosticpro">
+          <p class="expand-desc">Consumer-facing AI diagnostic platform that helps users troubleshoot equipment issues using Vertex AI Gemini. Upload photos or describe symptoms, and get instant AI-powered diagnosis with repair cost estimates and step-by-step fix instructions. Covers vehicles, appliances, HVAC, and more. Pay-per-diagnosis model at $4.99 makes professional-grade diagnostics accessible to everyone.</p>
+          
+          <ul class="expand-list">
+            <li>Diagnose vehicle issues from symptoms or photos</li><li>Get accurate repair cost estimates before visiting a shop</li><li>Follow AI-guided troubleshooting steps</li><li>Track maintenance history and upcoming service needs</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">React</span><span class="tag tech">Firebase</span><span class="tag tech">Cloud Functions</span><span class="tag tech">Firestore</span>
+            <span class="tag agent">Vertex AI Gemini</span>
+          </div>
+          <a href="https://diagnosticpro.io" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -793,6 +730,66 @@
             
           </div>
           <a href="https://github.com/intent-solutions-io/drop" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
+      <div class="link-item" data-id="intent-genai-project-template">
+        <div class="link-row" onclick="toggleExpand('intent-genai-project-template')">
+          <div class="link-icon"><i class="fa-solid fa-layer-group"></i></div>
+          <div class="link-text">
+            <span class="link-title">GenAI Project Template</span>
+            <span class="link-desc">FastAPI + evals + Docker — LLM app in minutes</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-intent-genai-project-template">
+          <p class="expand-desc">Battle-tested Python project template for building LLM applications. Includes FastAPI server, CLI interface, prompt pack management, streaming support, and evaluation framework. Preconfigured CI/CD with GitHub Actions, Docker support, and structured logging via structlog.</p>
+          
+          <ul class="expand-list">
+            <li>Bootstrap new LLM projects in minutes</li><li>Run prompt evaluations with built-in framework</li><li>Deploy via Docker with production defaults</li><li>Manage prompt versions with prompt packs</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Python</span><span class="tag tech">FastAPI</span><span class="tag tech">Docker</span><span class="tag tech">structlog</span><span class="tag tech">GitHub Actions</span>
+            
+          </div>
+          <a href="https://github.com/intent-solutions-io/intent-genai-project-template" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
+      <div class="link-item" data-id="intent-catalog">
+        <div class="link-row" onclick="toggleExpand('intent-catalog')">
+          <div class="link-icon"><i class="fa-solid fa-folder-tree"></i></div>
+          <div class="link-text">
+            <span class="link-title">Intent Catalog</span>
+            <span class="link-desc">Version control and discovery API for plugin ecosystems</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-intent-catalog">
+          <p class="expand-desc">Centralized catalog system for managing Claude Code plugins, agent skills, and documentation assets. Provides versioning, dependency resolution, and discovery APIs. Built as the backbone for Intent Solutions' plugin ecosystem with full CRUD operations and metadata indexing.</p>
+          
+          <ul class="expand-list">
+            <li>Manage plugin versions and dependencies</li><li>Discover skills by capability or tag</li><li>Index and search documentation assets</li><li>Automate catalog updates via CI/CD</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Python</span><span class="tag tech">FastAPI</span><span class="tag tech">SQLite</span>
+            
+          </div>
+          <a href="https://github.com/intent-solutions-io/intent-catalog" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -938,7 +935,7 @@
             
               
               
-                <span class="badge stars">29 Stars</span>
+                <span class="badge stars">31 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -959,6 +956,38 @@
         </div>
       </div>
       
+      <div class="link-item" data-id="pipelinepilot">
+        <div class="link-row" onclick="toggleExpand('pipelinepilot')">
+          <div class="link-icon"><i class="fa-solid fa-rocket"></i></div>
+          <div class="link-text">
+            <span class="link-title">PipelinePilot</span>
+            <span class="link-desc">AI agents qualify leads and run multi-channel outreach</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">4 Stars</span>
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-pipelinepilot">
+          <p class="expand-desc">SDR orchestration platform that automates the entire outbound sales pipeline. AI agents qualify leads using firmographic and technographic signals, craft personalized outreach sequences, and manage multi-channel follow-ups across email, LinkedIn, and phone. Integrates with major CRMs and provides real-time pipeline analytics. Built on Google ADK for reliable, scalable agent execution.</p>
+          
+          <ul class="expand-list">
+            <li>Automated lead scoring and qualification with AI</li><li>Personalized multi-channel outreach sequences</li><li>CRM integration and pipeline sync</li><li>Real-time sales analytics and forecasting</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Python</span><span class="tag tech">Firestore</span><span class="tag tech">Cloud Run</span><span class="tag tech">BigQuery</span>
+            <span class="tag agent">Google ADK</span><span class="tag agent">Vertex AI Agent Engine</span>
+          </div>
+          <a href="https://pipelinepilot-prod.web.app" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
       <div class="link-item" data-id="costplusdb">
         <div class="link-row" onclick="toggleExpand('costplusdb')">
           <div class="link-icon"><i class="fa-solid fa-database"></i></div>
@@ -970,8 +999,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1003,8 +1031,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1036,8 +1063,7 @@
             
               
               
-                <span class="badge stars">1 Star</span>
-                
+                <span class="badge stars">2 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1111,36 +1137,6 @@
             <span class="tag agent">Claude Code</span><span class="tag agent">OpenAI Codex</span>
           </div>
           <a href="https://www.upwork.com/freelancers/jeremylongshore" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
-      <div class="link-item" data-id="pipelinepilot">
-        <div class="link-row" onclick="toggleExpand('pipelinepilot')">
-          <div class="link-icon"><i class="fa-solid fa-rocket"></i></div>
-          <div class="link-text">
-            <span class="link-title">PipelinePilot</span>
-            <span class="link-desc">AI agents qualify leads and run multi-channel outreach</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-pipelinepilot">
-          <p class="expand-desc">SDR orchestration platform that automates the entire outbound sales pipeline. AI agents qualify leads using firmographic and technographic signals, craft personalized outreach sequences, and manage multi-channel follow-ups across email, LinkedIn, and phone. Integrates with major CRMs and provides real-time pipeline analytics. Built on Google ADK for reliable, scalable agent execution.</p>
-          
-          <ul class="expand-list">
-            <li>Automated lead scoring and qualification with AI</li><li>Personalized multi-channel outreach sequences</li><li>CRM integration and pipeline sync</li><li>Real-time sales analytics and forecasting</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Python</span><span class="tag tech">Firestore</span><span class="tag tech">Cloud Run</span><span class="tag tech">BigQuery</span>
-            <span class="tag agent">Google ADK</span><span class="tag agent">Vertex AI Agent Engine</span>
-          </div>
-          <a href="https://pipelinepilot-prod.web.app" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -1243,7 +1239,7 @@
             
               
               
-                <span class="badge stars">6 Stars</span>
+                <span class="badge stars">8 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1283,39 +1279,7 @@
           
             
             
-              <span class="badge stars">11 Stars</span>
-            
-          
-        </div>
-      </a>
-      
-      <a href="https://jeremylongshore.github.io/disposable-marketplace-n8n/" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-cart-shopping"></i></div>
-        <div class="link-text">
-          <span class="link-title">Disposable Marketplace</span>
-          <span class="link-desc">Reseller outreach and quote collection automation</span>
-        </div>
-        <div class="link-badge">
-          
-            
-            
-              <span class="badge stars">4 Stars</span>
-            
-          
-        </div>
-      </a>
-      
-      <a href="https://jeremylongshore.github.io/gmail-drive-organizer-n8n/" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-envelope-open-text"></i></div>
-        <div class="link-text">
-          <span class="link-title">Gmail Drive Organizer</span>
-          <span class="link-desc">Auto-organize Gmail attachments to Drive</span>
-        </div>
-        <div class="link-badge">
-          
-            
-            
-              <span class="badge stars">4 Stars</span>
+              <span class="badge stars">15 Stars</span>
             
           
         </div>
@@ -1331,7 +1295,39 @@
           
             
             
-              <span class="badge stars">3 Stars</span>
+              <span class="badge stars">7 Stars</span>
+            
+          
+        </div>
+      </a>
+      
+      <a href="https://jeremylongshore.github.io/gmail-drive-organizer-n8n/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-envelope-open-text"></i></div>
+        <div class="link-text">
+          <span class="link-title">Gmail Drive Organizer</span>
+          <span class="link-desc">Auto-organize Gmail attachments to Drive</span>
+        </div>
+        <div class="link-badge">
+          
+            
+            
+              <span class="badge stars">6 Stars</span>
+            
+          
+        </div>
+      </a>
+      
+      <a href="https://jeremylongshore.github.io/disposable-marketplace-n8n/" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-cart-shopping"></i></div>
+        <div class="link-text">
+          <span class="link-title">Disposable Marketplace</span>
+          <span class="link-desc">Reseller outreach and quote collection automation</span>
+        </div>
+        <div class="link-badge">
+          
+            
+            
+              <span class="badge stars">5 Stars</span>
             
           
         </div>
@@ -1347,8 +1343,7 @@
           
             
             
-              <span class="badge stars">1 Star</span>
-              
+              <span class="badge stars">2 Stars</span>
             
           
         </div>
@@ -1544,5 +1539,8 @@
     gtag('config', 'G-40E6F2PYMQ');
   </script>
   
+
+  <!-- Credly badge embed (Claude Partner Network certification card) -->
+  <script type="text/javascript" async src="https://www.credly.com/assets/utilities/embed.js"></script>
 </body>
 </html>

--- a/_output/styles.css
+++ b/_output/styles.css
@@ -425,6 +425,30 @@ a.section-header:hover i {
   color: #2E7D32;
 }
 
+.badge.date {
+  background: #EDE7F6;
+  color: #5E35B1;
+  font-variant-numeric: tabular-nums;
+}
+
+.blog-section .section-intro {
+  margin-bottom: 4px;
+}
+
+.view-all-link {
+  display: block;
+  text-align: center;
+  margin-top: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #2563EB;
+  text-decoration: none;
+  padding: 8px;
+}
+.view-all-link:hover {
+  text-decoration: underline;
+}
+
 .expand-icon {
   width: 24px;
   height: 24px;

--- a/_output/styles.css
+++ b/_output/styles.css
@@ -76,6 +76,76 @@ body {
   color: #cbd5e0;
 }
 
+/* Credly Badge — Claude Partner Network certification */
+.credly-card {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin: 24px auto 0;
+  max-width: 520px;
+  padding: 16px 20px;
+  background: #f7f8fa;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  text-align: left;
+}
+
+.credly-badge {
+  flex: 0 0 auto;
+  width: 150px;
+  min-height: 270px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.credly-badge > div {
+  width: 150px;
+  height: 270px;
+}
+
+.credly-meta {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.credly-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #CE1141; /* Braves Red — eyebrow accent */
+  margin-bottom: 4px;
+}
+
+.credly-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #0C2340; /* Braves Navy */
+  line-height: 1.35;
+  margin-bottom: 6px;
+}
+
+.credly-desc {
+  font-size: 13px;
+  color: #4a5568; /* Slate gray */
+  line-height: 1.5;
+  margin: 0 0 8px 0;
+}
+
+.credly-link {
+  font-size: 12px;
+  font-weight: 600;
+  color: #CE1141; /* Braves Red */
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.credly-link:hover {
+  color: #0C2340; /* Braves Navy */
+  text-decoration: underline;
+}
+
 /* Productivity Approach Section */
 .productivity-approach {
   margin-bottom: 40px;
@@ -771,5 +841,22 @@ footer a:hover {
     justify-content: center;
     min-height: 48px;
     padding: 14px 24px;
+  }
+
+  .credly-card {
+    flex-direction: column;
+    text-align: center;
+    padding: 18px 16px;
+  }
+
+  .credly-badge {
+    margin: 0 auto;
+  }
+
+  .credly-eyebrow,
+  .credly-title,
+  .credly-desc,
+  .credly-link {
+    text-align: center;
   }
 }

--- a/data/blog_posts.yml
+++ b/data/blog_posts.yml
@@ -1,0 +1,39 @@
+- title: "X Bug Triage Plugin: Zero to v0.4.3 in One Day"
+  date: "2026-03-23"
+  description: "A brand-new MCP plugin that triages X/Twitter bug reports shipped 10 epics, 13 releases, 89 tests, and 4 extracted sub-agents."
+  url: "https://startaitools.com/posts/x-bug-triage-plugin-zero-to-v043-one-day/"
+
+- title: "Ninety Skills, Three Packs, One Day"
+  date: "2026-03-22"
+  description: "Building three complete 30-skill SaaS integration packs — Sentry, Notion, and Supabase — in a single day."
+  url: "https://startaitools.com/posts/ninety-skills-three-packs-one-day/"
+
+- title: "Nuclear Option Day: Validator Rewrite, 63 New Packs, 414 Plugins"
+  date: "2026-03-21"
+  description: "Rewrote the universal validator from scratch to match Anthropic's 14-field spec, generated 63 SaaS packs."
+  url: "https://startaitools.com/posts/nuclear-option-day-validator-rewrite-414-plugins/"
+
+- title: "58 E2E Tests, a Slack Channel Launch, and the Auth Injection That Made It Work"
+  date: "2026-03-20"
+  description: "How REST API auth plus IndexedDB injection unlocked 58 production E2E tests for cad-dxf-agent."
+  url: "https://startaitools.com/posts/58-e2e-tests-slack-channel-launch-one-day/"
+
+- title: "Governed Knowledge: Two Major Releases, a Freshness Daemon, and Export Gating"
+  date: "2026-03-19"
+  description: "qmd-team-intent-kb ships v0.2.0 and v0.3.0 in one day — freshness-aware search with exponential decay."
+  url: "https://startaitools.com/posts/governed-knowledge-two-releases-freshness-daemon/"
+
+- title: "Knowledge Base from Zero to API: Lifecycle State Machines and Policy Engines"
+  date: "2026-03-18"
+  description: "Building a team knowledge base with lifecycle state machines, policy engines, and git-exported articles."
+  url: "https://startaitools.com/posts/knowledge-base-zero-to-api-lifecycle-state-machine/"
+
+- title: "Content Quality War: 7-Check Audit Across 340 Plugins"
+  date: "2026-03-17"
+  description: "A 7-category audit script found boilerplate openings, empty shells, reference stubs, and duplicate content."
+  url: "https://startaitools.com/posts/content-quality-war-7-check-audit-across-340-plugins/"
+
+- title: "Meta-Agent Orchestration and the UX of Removing Features"
+  date: "2026-03-16"
+  description: "The oss-agent-lab ships its meta-agent capstone — one agent to orchestrate nine specialists."
+  url: "https://startaitools.com/posts/meta-agent-orchestration-and-the-ux-of-removing-features/"

--- a/scaffold.rb
+++ b/scaffold.rb
@@ -29,6 +29,14 @@ else
   settings["projects"] = []
 end
 
+# Load blog posts from data file
+blog_posts_file = "./data/blog_posts.yml"
+if File.exist?(blog_posts_file)
+  settings["blog_posts"] = YAML.load_file(blog_posts_file) || []
+else
+  settings["blog_posts"] = []
+end
+
 # Collect GitHub repos from all projects for star fetching
 all_projects = settings["intent_solutions_repos"] + settings["products"] + settings["personal_repos"] + settings["client_projects"] + settings["n8n_workflows"]
 github_repos = all_projects

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -328,6 +328,29 @@
       <a href="{{ booking_url }}" target="_blank" class="cta-link">Let's talk →</a>
     </section>
 
+    {% if blog_posts.size > 0 %}
+    <section class="links blog-section">
+      <a href="https://startaitools.com/posts/" target="_blank" class="section-header">
+        <h2 class="section-label">Latest Writing</h2>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+      </a>
+      <p class="section-intro">Technical deep-dives on AI agents, plugin development, and production systems.</p>
+      {% for post in blog_posts %}
+      <a href="{{ post.url }}" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">{{ post.title }}</span>
+          <span class="link-desc">{{ post.description }}</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">{{ post.date }}</span>
+        </div>
+      </a>
+      {% endfor %}
+      <a href="https://startaitools.com/posts/" target="_blank" class="view-all-link">View all posts →</a>
+    </section>
+    {% endif %}
+
     <nav class="socials">
       {% for item in socials %}
       {% assign s = item.social %}

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -30,6 +30,18 @@
         <span>·</span>
         <a href="https://startaitools.com" target="_blank">startaitools.com</a>
       </p>
+
+      <aside class="credly-card" aria-label="Claude Partner Network certification">
+        <div class="credly-badge">
+          <div data-iframe-width="150" data-iframe-height="270" data-share-badge-id="ddf22fb4-0aa6-46b3-a93b-0b45b509e471" data-share-badge-host="https://www.credly.com"></div>
+        </div>
+        <div class="credly-meta">
+          <div class="credly-eyebrow">Anthropic-issued</div>
+          <div class="credly-title">Claude Partner Badge &middot; Claude Code</div>
+          <p class="credly-desc">Certified through the Claude Partner Network to scope, deploy, configure, and run Claude Code activations end-to-end. Eight-course program with a scenario-based capstone.</p>
+          <a class="credly-link" href="https://www.credly.com/badges/ddf22fb4-0aa6-46b3-a93b-0b45b509e471" target="_blank" rel="noopener noreferrer">Verify on Credly &rarr;</a>
+        </div>
+      </aside>
     </header>
 
     <section class="contact-cta top">
@@ -394,5 +406,8 @@
     gtag('config', '{{ google_analytics_id }}');
   </script>
   {% endif %}
+
+  <!-- Credly badge embed (Claude Partner Network certification card) -->
+  <script type="text/javascript" async src="https://www.credly.com/assets/utilities/embed.js"></script>
 </body>
 </html>

--- a/themes/default/styles.css
+++ b/themes/default/styles.css
@@ -425,6 +425,30 @@ a.section-header:hover i {
   color: #2E7D32;
 }
 
+.badge.date {
+  background: #EDE7F6;
+  color: #5E35B1;
+  font-variant-numeric: tabular-nums;
+}
+
+.blog-section .section-intro {
+  margin-bottom: 4px;
+}
+
+.view-all-link {
+  display: block;
+  text-align: center;
+  margin-top: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #2563EB;
+  text-decoration: none;
+  padding: 8px;
+}
+.view-all-link:hover {
+  text-decoration: underline;
+}
+
 .expand-icon {
   width: 24px;
   height: 24px;

--- a/themes/default/styles.css
+++ b/themes/default/styles.css
@@ -76,6 +76,76 @@ body {
   color: #cbd5e0;
 }
 
+/* Credly Badge — Claude Partner Network certification */
+.credly-card {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin: 24px auto 0;
+  max-width: 520px;
+  padding: 16px 20px;
+  background: #f7f8fa;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  text-align: left;
+}
+
+.credly-badge {
+  flex: 0 0 auto;
+  width: 150px;
+  min-height: 270px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.credly-badge > div {
+  width: 150px;
+  height: 270px;
+}
+
+.credly-meta {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.credly-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #CE1141; /* Braves Red — eyebrow accent */
+  margin-bottom: 4px;
+}
+
+.credly-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #0C2340; /* Braves Navy */
+  line-height: 1.35;
+  margin-bottom: 6px;
+}
+
+.credly-desc {
+  font-size: 13px;
+  color: #4a5568; /* Slate gray */
+  line-height: 1.5;
+  margin: 0 0 8px 0;
+}
+
+.credly-link {
+  font-size: 12px;
+  font-weight: 600;
+  color: #CE1141; /* Braves Red */
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.credly-link:hover {
+  color: #0C2340; /* Braves Navy */
+  text-decoration: underline;
+}
+
 /* Productivity Approach Section */
 .productivity-approach {
   margin-bottom: 40px;
@@ -771,5 +841,22 @@ footer a:hover {
     justify-content: center;
     min-height: 48px;
     padding: 14px 24px;
+  }
+
+  .credly-card {
+    flex-direction: column;
+    text-align: center;
+    padding: 18px 16px;
+  }
+
+  .credly-badge {
+    margin: 0 auto;
+  }
+
+  .credly-eyebrow,
+  .credly-title,
+  .credly-desc,
+  .credly-link {
+    text-align: center;
   }
 }


### PR DESCRIPTION
## What
Adds the Anthropic-issued Claude Partner Network certification (Claude Code) to the profile header on jeremylongshore.com as a structured credential card. Wraps the Credly embed (150×270) with eyebrow + title + description + verify link so it reads as a real credential, not a sticker.

## Why
The credential was earned through Anthropic's eight-course Claude Partner Network program with a scenario-based capstone. The bare 150×270 Credly embed on its own is a narrow column that reads as an off-brand ad slot; wrapping it in a card that matches the site's established style (Braves Navy `#0C2340` + Braves Red `#CE1141` eyebrow + Inter typography + soft card with `#e2e8f0` border, matching the existing `.productivity-approach` and `.cta-buttons` card families) lifts it into a real credential.

## Where
- `themes/default/index.html` — new `<aside class="credly-card">` inside the existing `<header class="profile">`, between `.site-links` and the contact CTA. Includes the Credly `embed.js` loader at the bottom of `<body>`.
- `themes/default/styles.css` — new `.credly-card` + `.credly-*` family. Two-column flex on desktop (150px badge | text meta), stacks centered on ≤480px. Reuses existing color tokens.
- `_output/index.html` + `_output/styles.css` — regenerated via `bundle exec ruby ./scaffold.rb` so the rendered output matches the theme source (CI uses `_output/`).

## How it works
The card sits as a flex container:

- **Left column (150px fixed):** the Credly iframe (data-share-badge-id `ddf22fb4-0aa6-46b3-a93b-0b45b509e471`).
- **Right column (flex 1 1 auto):** eyebrow (`Anthropic-issued` in Braves Red), title (`Claude Partner Badge · Claude Code` in Braves Navy 700-weight), description (one-paragraph cap+deliverables summary), and a verify link (`Verify on Credly →` linking to the public Credly URL).

Renders on every page load (no gate needed — the homepage IS the profile page here, no separate `/about/` surface). The Credly embed script is `async` and deduped by the browser across pages.

## Verification

**Local build:**
```
$ bundle exec ruby ./scaffold.rb  # exits 0, regenerates _output/
```

**Render check on `_output/index.html`:**
- Exactly 1 occurrence of `credly.com/assets/utilities/embed.js` at the bottom of `<body>`.
- `<aside class="credly-card">` with full `credly-badge | credly-meta` structure present in `<header class="profile">` between `.site-links` and the contact-cta section.
- All 6 `.credly-*` CSS rules present in `_output/styles.css`.

**Visual proof pending:** VPS deploy after merge.

## Risk
- **Low.** Pure markup + CSS + a third-party embed. No schema, no DB, no dependency upgrade.
- **No secret leak** — the Credly badge is public-facing.
- **Embed cost**: ~10KB async JS from `credly.com`, fires on every page. Acceptable for a static landing page where users scroll once.
- **Backwards compatible**: zero structural changes to existing sections; the new card is purely additive inside the profile header.

## Operational impact
- Deploy: merges to `main` → existing VPS deploy workflow (per `claude-code-plugins-plus-skills` patterns + the deploy-audit report).
- No migrations, no env changes, no new deps.
- Post-merge verify: visit `https://jeremylongshore.com/` and confirm the badge iframe loads + the card lays out as expected (badge left, text right on desktop; stacked on mobile).

## Follow-up
- If the badge gets re-issued / re-branded, the partial-equivalent markup is the single edit point — just swap the `data-share-badge-id` and the `Verify on Credly` link in both `themes/default/index.html` and re-run `scaffold.rb`.
- The footer still says "1,300+ stars" — separate bead `startaitools-9ve` (filed under startaitools, scoped to jeremylongshore.com) tracks wiring the star count to the live `GithubRepoStarsCountPlugin` so the count stops drifting. Out of scope here.

## Refs
- Anthropic Claude Partner Network program (badge `ddf22fb4-0aa6-46b3-a93b-0b45b509e471`, issued to Jeremy Longshore).
- Companion PR: `jeremylongshore/startaitools.com#36` (same badge on startaitools.com `/about/`).
- Credly embed docs: https://info.credly.com/developers

- Jeremy Longshore
intentsolutions.io