### PR TITLE
feat(profile): add Claude Partner Network certification card to profile header

### DIFF
--- a/_output/index.html
+++ b/_output/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jeremy Longshore - I Make Teams AI-Native</title>
-  <meta name="last-modified" content="2026-07-19T14:55:17-0600">
-  <meta name="theme-color" content="#faf8f4">
+  <meta name="last-modified" content="2026-07-26T19:48:09-0600">
+  <meta name="theme-color" content="#FFFFFF">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="description" content="I build AI systems that ship and train teams to work with coding agents — Claude, Codex, Gemini, whatever moves the needle. 20+ years ops, self-taught dev, 60+ repos with real GitHub stars." />
   <meta property="og:title" content="Jeremy Longshore - I Make Teams AI-Native" />
@@ -15,10 +15,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="./images/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="./images/favicons/favicon-32x32.png">
   <link rel="shortcut icon" href="./images/favicons/favicon.ico">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=2026-07-19T14:55:17-0600" />
+  <link rel="stylesheet" href="./styles.css?v=2026-07-26T19:48:09-0600" />
 </head>
 <body>
   <div class="container">
@@ -33,6 +30,18 @@
         <span>·</span>
         <a href="https://startaitools.com" target="_blank">startaitools.com</a>
       </p>
+
+      <aside class="credly-card" aria-label="Claude Partner Network certification">
+        <div class="credly-badge">
+          <div data-iframe-width="150" data-iframe-height="270" data-share-badge-id="ddf22fb4-0aa6-46b3-a93b-0b45b509e471" data-share-badge-host="https://www.credly.com"></div>
+        </div>
+        <div class="credly-meta">
+          <div class="credly-eyebrow">Anthropic-issued</div>
+          <div class="credly-title">Claude Partner Badge &middot; Claude Code</div>
+          <p class="credly-desc">Certified through the Claude Partner Network to scope, deploy, configure, and run Claude Code activations end-to-end. Eight-course program with a scenario-based capstone.</p>
+          <a class="credly-link" href="https://www.credly.com/badges/ddf22fb4-0aa6-46b3-a93b-0b45b509e471" target="_blank" rel="noopener noreferrer">Verify on Credly &rarr;</a>
+        </div>
+      </aside>
     </header>
 
     <section class="contact-cta top">
@@ -43,16 +52,6 @@
         <a href="https://intentsolutions.io/contact" target="_blank" class="btn btn-secondary">
           <i class="fa-solid fa-envelope"></i> Send a Message
         </a>
-      </div>
-    </section>
-
-    <section class="featured-coaching">
-      <span class="fc-eyebrow">Learn with Jeremy</span>
-      <h2 class="fc-title">Your project. My methodology.</h2>
-      <p class="fc-desc">1:1 coaching on AI coding agents &mdash; Claude Code, Codex, Gemini, whatever moves the needle. You bring your real codebase; I bring the methodology that actually ships. Starter, Standard, and full-day deep dives.</p>
-      <div class="fc-actions">
-        <a href="https://calendar.app.google/Wqbt8EJuEh5xvvV58" target="_blank" class="btn btn-primary"><i class="fa-solid fa-calendar"></i> Book a session</a>
-        <a href="https://www.upwork.com/freelancers/jeremylongshore" target="_blank" class="btn btn-secondary">See the tiers</a>
       </div>
     </section>
 
@@ -105,7 +104,7 @@
             
               
               
-                <span class="badge stars">2530 Stars</span>
+                <span class="badge stars">2557 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -137,7 +136,7 @@
             
               
               
-                <span class="badge stars">48 Stars</span>
+                <span class="badge stars">49 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -201,7 +200,7 @@
             
               
               
-                <span class="badge stars">13 Stars</span>
+                <span class="badge stars">15 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -478,38 +477,6 @@
         </div>
       </div>
       
-      <div class="link-item" data-id="moat">
-        <div class="link-row" onclick="toggleExpand('moat')">
-          <div class="link-icon"><i class="fa-solid fa-shield"></i></div>
-          <div class="link-text">
-            <span class="link-title">Moat</span>
-            <span class="link-desc">Verified Agent Capabilities Marketplace — MCP trust layer</span>
-          </div>
-          <div class="link-badge">
-            
-              
-              
-                <span class="badge stars">2 Stars</span>
-              
-            
-            <span class="expand-icon">+</span>
-          </div>
-        </div>
-        <div class="link-expand" id="expand-moat">
-          <p class="expand-desc">Verified Agent Capabilities Marketplace providing an MCP-first trust, policy, and execution layer for AI agents. Establishes verified capability claims, enforced policies, and auditable execution for agent-to-agent interactions in production environments.</p>
-          
-          <ul class="expand-list">
-            <li>Verified agent capability claims and discovery</li><li>Policy enforcement for agent interactions</li><li>Trust layer for MCP-based agent ecosystems</li><li>Auditable execution records for agent operations</li>
-          </ul>
-          
-          <div class="expand-tags">
-            <span class="tag tech">Python</span><span class="tag tech">MCP Protocol</span><span class="tag tech">FastAPI</span>
-            <span class="tag agent">MCP Servers</span>
-          </div>
-          <a href="https://github.com/jeremylongshore/moat" target="_blank" class="expand-link">Open &rarr;</a>
-        </div>
-      </div>
-      
       <div class="link-item" data-id="oss-agent-lab">
         <div class="link-row" onclick="toggleExpand('oss-agent-lab')">
           <div class="link-icon"><i class="fa-solid fa-flask"></i></div>
@@ -571,6 +538,39 @@
             <span class="tag agent">MCP Protocol</span>
           </div>
           <a href="https://github.com/jeremylongshore/waygate-mcp" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
+      
+      <div class="link-item" data-id="moat">
+        <div class="link-row" onclick="toggleExpand('moat')">
+          <div class="link-icon"><i class="fa-solid fa-shield"></i></div>
+          <div class="link-text">
+            <span class="link-title">Moat</span>
+            <span class="link-desc">Verified Agent Capabilities Marketplace — MCP trust layer</span>
+          </div>
+          <div class="link-badge">
+            
+              
+              
+                <span class="badge stars">1 Star</span>
+                
+              
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-moat">
+          <p class="expand-desc">Verified Agent Capabilities Marketplace providing an MCP-first trust, policy, and execution layer for AI agents. Establishes verified capability claims, enforced policies, and auditable execution for agent-to-agent interactions in production environments.</p>
+          
+          <ul class="expand-list">
+            <li>Verified agent capability claims and discovery</li><li>Policy enforcement for agent interactions</li><li>Trust layer for MCP-based agent ecosystems</li><li>Auditable execution records for agent operations</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Python</span><span class="tag tech">MCP Protocol</span><span class="tag tech">FastAPI</span>
+            <span class="tag agent">MCP Servers</span>
+          </div>
+          <a href="https://github.com/jeremylongshore/moat" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
       
@@ -895,7 +895,7 @@
             
               
               
-                <span class="badge stars">29 Stars</span>
+                <span class="badge stars">30 Stars</span>
               
             
             <span class="expand-icon">+</span>
@@ -1391,7 +1391,6 @@
         <h2 class="section-label">Products</h2>
       </div>
       
-      
       <div class="link-item" data-id="gastown-viewer">
         <div class="link-row" onclick="toggleExpand('gastown-viewer')">
           <div class="link-icon"><i class="fa-solid fa-gauge-high"></i></div>
@@ -1423,8 +1422,6 @@
           <a href="https://github.com/intent-solutions-io/gastown-viewer-intent" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
-      
-      
       
       <div class="link-item" data-id="pipelinepilot">
         <div class="link-row" onclick="toggleExpand('pipelinepilot')">
@@ -1458,8 +1455,6 @@
         </div>
       </div>
       
-      
-      
       <div class="link-item" data-id="hustlestats">
         <div class="link-row" onclick="toggleExpand('hustlestats')">
           <div class="link-icon"><i class="fa-solid fa-futbol"></i></div>
@@ -1491,8 +1486,6 @@
           <a href="https://hustlestats.io" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
-      
-      
       
       <div class="link-item" data-id="stci">
         <div class="link-row" onclick="toggleExpand('stci')">
@@ -1526,8 +1519,6 @@
         </div>
       </div>
       
-      
-      
       <div class="link-item" data-id="intentsolutions">
         <div class="link-row" onclick="toggleExpand('intentsolutions')">
           <div class="link-icon"><i class="fa-solid fa-building-columns"></i></div>
@@ -1557,137 +1548,36 @@
         </div>
       </div>
       
-      
-      
+      <div class="link-item" data-id="learn-with-jeremy">
+        <div class="link-row" onclick="toggleExpand('learn-with-jeremy')">
+          <div class="link-icon"><i class="fa-solid fa-graduation-cap"></i></div>
+          <div class="link-text">
+            <span class="link-title">Learn with Jeremy</span>
+            <span class="link-desc">1:1 AI coding agent coaching — your project, my methodology</span>
+          </div>
+          <div class="link-badge">
+            
+            <span class="expand-icon">+</span>
+          </div>
+        </div>
+        <div class="link-expand" id="expand-learn-with-jeremy">
+          <p class="expand-desc">White-glove 1:1 coaching on AI coding agents for founders, engineers, and teams. Claude Code, Codex, Gemini Code Assist — I teach the methodology that works across all of them. You bring your real project. Starter (30 min) covers agent basics and your first workflow. Standard (90 min + follow-up) builds custom automations. Advanced (full day) architects production agent infrastructure end-to-end. Book via Upwork or schedule directly.</p>
+          
+          <ul class="expand-list">
+            <li>Get productive with AI coding agents in one session</li><li>Design custom plugins and MCP integrations for your stack</li><li>Build multi-agent workflows on your actual codebase</li><li>Architecture review for production AI systems</li>
+          </ul>
+          
+          <div class="expand-tags">
+            <span class="tag tech">Claude Code</span><span class="tag tech">Codex</span><span class="tag tech">MCP Protocol</span><span class="tag tech">Google Cloud</span>
+            <span class="tag agent">Claude Code</span><span class="tag agent">OpenAI Codex</span>
+          </div>
+          <a href="https://www.upwork.com/freelancers/jeremylongshore" target="_blank" class="expand-link">Open &rarr;</a>
+        </div>
+      </div>
       
     </section>
     
 
-    
-    
-    <section class="links">
-      <a href="https://github.com/pulls?q=is%3Apr%20author%3Ajeremylongshore%20is%3Amerged" target="_blank" class="section-header">
-        <h2 class="section-label">Open Source Contributions</h2>
-        <span class="contribution-count">29 PRs &middot; 15 repos</span>
-      </a>
-      
-      <a href="https://github.com/kobiton/automate/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-mobile-screen"></i></div>
-        <div class="link-text">
-          <span class="link-title">Kobiton Automate</span>
-          <span class="link-desc">Mobile device-cloud test automation contributions</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge contrib">10 PRs</span>
-        </div>
-      </a>
-      
-      <a href="https://github.com/pabs-ai/blur-extension/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-eye-slash"></i></div>
-        <div class="link-text">
-          <span class="link-title">Blur Extension</span>
-          <span class="link-desc">Teams, Slack, export/import, custom patterns</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge contrib">4 PRs</span>
-        </div>
-      </a>
-      
-      <a href="https://github.com/gastownhall/beads/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-link"></i></div>
-        <div class="link-text">
-          <span class="link-title">Beads</span>
-          <span class="link-desc">Natural-language skill activation and core fixes</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge contrib">2 PRs</span>
-        </div>
-      </a>
-      
-      <a href="https://github.com/PostHog/posthog/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-chart-simple"></i></div>
-        <div class="link-text">
-          <span class="link-title">PostHog</span>
-          <span class="link-desc">React state management and feature-flag bug fixes</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge contrib">2 PRs</span>
-        </div>
-      </a>
-      
-      <a href="https://github.com/Kilo-Org/kilocode/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-robot"></i></div>
-        <div class="link-text">
-          <span class="link-title">Kilo Code</span>
-          <span class="link-desc">Agent runtime test fix</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge contrib">1 PR</span>
-        </div>
-      </a>
-      
-      <a href="https://github.com/tldraw/tldraw/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-pen-ruler"></i></div>
-        <div class="link-text">
-          <span class="link-title">tldraw</span>
-          <span class="link-desc">Prettier extension fix</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge contrib">1 PR</span>
-        </div>
-      </a>
-      
-      <a href="https://github.com/filamentphp/filament/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-solid fa-layer-group"></i></div>
-        <div class="link-text">
-          <span class="link-title">Filament</span>
-          <span class="link-desc">Dark mode fix</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge contrib">1 PR</span>
-        </div>
-      </a>
-      
-      <a href="https://github.com/GoogleCloudPlatform/vertex-ai-samples/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-brands fa-google"></i></div>
-        <div class="link-text">
-          <span class="link-title">Vertex AI Samples</span>
-          <span class="link-desc">ADK inline-source deployment tutorial for Agent Engine</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge contrib">1 PR</span>
-        </div>
-      </a>
-      
-      <a href="https://github.com/GoogleCloudPlatform/agent-starter-pack/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="link-item simple">
-        <div class="link-icon"><i class="fa-brands fa-google"></i></div>
-        <div class="link-text">
-          <span class="link-title">Agent Starter Pack</span>
-          <span class="link-desc">Bob's Brain production ADK reference in the community showcase</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge contrib">1 PR</span>
-        </div>
-      </a>
-      
-      
-      <div class="contributions-footer">
-        
-        <a href="https://github.com/SpillwaveSolutions/agent-brain/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="contrib-other">agent-brain &middot; 1</a>
-        
-        <a href="https://github.com/thejeremyhodge/xireactor-brilliant/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="contrib-other">xireactor-brilliant &middot; 1</a>
-        
-        <a href="https://github.com/gastownhall/wasteland/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="contrib-other">wasteland &middot; 1</a>
-        
-        <a href="https://github.com/abubakarsiddik31/claude-skills-collection/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="contrib-other">claude-skills-collection &middot; 1</a>
-        
-        <a href="https://github.com/VoltAgent/awesome-agent-skills/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="contrib-other">awesome-agent-skills &middot; 1</a>
-        
-        <a href="https://github.com/cxlinux-ai/cx-core/pulls?q=is%3Apr+author%3Ajeremylongshore+is%3Amerged" target="_blank" class="contrib-other">cx-core &middot; 1</a>
-        
-      </div>
-      
-    </section>
     
 
     
@@ -1821,87 +1711,6 @@
     </section>
     
 
-    
-    <section class="links work-diary">
-      <a href="https://startaitools.com" target="_blank" class="section-header">
-        <h2 class="section-label">Work Diary</h2>
-        <span class="article-count">6 latest</span>
-      </a>
-      <p class="section-intro">What I'm building, breaking, and shipping — direct from the commit log.</p>
-      
-      <a href="https://startaitools.com/posts/a-green-recovery-drill-can-still-be-lying/" target="_blank" class="link-item simple article-item">
-        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
-        <div class="link-text">
-          <span class="link-title">A Green Recovery Drill Can Still Be Lying</span>
-          <span class="link-desc">We had a backup mechanism for a SigNoz staging stack. What we did not have was a proven restore. Those are different claims, and the gap betw...</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge article-date">Jul 18, 2026</span>
-        </div>
-      </a>
-      
-      <a href="https://startaitools.com/posts/let-the-model-judge-make-the-code-decide/" target="_blank" class="link-item simple article-item">
-        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
-        <div class="link-text">
-          <span class="link-title">Let the Model Judge. Make the Code Decide.</span>
-          <span class="link-desc">This post was written by the pipeline it describes. The transcript analyzer that runs on every build day looked at the work that produced thi...</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge article-date">Jul 17, 2026</span>
-        </div>
-      </a>
-      
-      <a href="https://startaitools.com/posts/copying-files-is-not-installing/" target="_blank" class="link-item simple article-item">
-        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
-        <div class="link-text">
-          <span class="link-title">Copying Files Is Not Installing</span>
-          <span class="link-desc">A marketplace install copies your plugin&rsquo;s files into place. It does not run npm install in them. Those are two different operations, a...</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge article-date">Jul 16, 2026</span>
-        </div>
-      </a>
-      
-      <a href="https://startaitools.com/posts/producer-fallback-when-claude-hits-weekly-limit/" target="_blank" class="link-item simple article-item">
-        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
-        <div class="link-text">
-          <span class="link-title">Producer Fallback: When Claude Hits the Weekly Limit, the Pipeline Still Ships</span>
-          <span class="link-desc">A daily content pipeline that dies because one model returns a rate-limit error is measuring the wrong success criterion. The job is not &ldq...</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge article-date">Jul 15, 2026</span>
-        </div>
-      </a>
-      
-      <a href="https://startaitools.com/posts/exit-0-is-not-success/" target="_blank" class="link-item simple article-item">
-        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
-        <div class="link-text">
-          <span class="link-title">Exit 0 Is Not Success: Automation Assurance That Verifies Outcomes</span>
-          <span class="link-desc">A cron that exits zero and produces nothing is not healthy. It is a silent failure wearing a green badge.
-That distinction drove most of 2026...</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge article-date">Jul 14, 2026</span>
-        </div>
-      </a>
-      
-      <a href="https://startaitools.com/posts/empty-is-not-clean/" target="_blank" class="link-item simple article-item">
-        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
-        <div class="link-text">
-          <span class="link-title">Empty Is Not Clean: Five Fail-Open Bugs in an AI Agent</span>
-          <span class="link-desc">A policy said deny anything under /etc. A Bash call read /etc/shadow and came back {allow, rule: 'trust-bash'}. No human in the loop. The den...</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge article-date">Jul 13, 2026</span>
-        </div>
-      </a>
-      
-      <div class="article-footer">
-        <a href="https://startaitools.com" target="_blank" class="expand-link">Read all posts →</a>
-      </div>
-    </section>
-    
-
     <section class="who-i-work-with">
       <h2>Who I Work With</h2>
       <p>I work with organizations adopting AI — from startups building their first agent to enterprises rolling out coding tools across 500 engineers.</p>
@@ -1913,6 +1722,8 @@ That distinction drove most of 2026...</span>
       </ul>
       <a href="https://calendar.app.google/Wqbt8EJuEh5xvvV58" target="_blank" class="cta-link">Let's talk →</a>
     </section>
+
+    
 
     <nav class="socials">
       
@@ -1989,6 +1800,8 @@ That distinction drove most of 2026...</span>
     gtag('config', 'G-40E6F2PYMQ');
   </script>
   
-  <script defer src="https://analytics.intentsolutions.io/script.js" data-website-id="3cea8ff2-5842-4090-a8a3-d2dc128f5385"></script>
+
+  <!-- Credly badge embed (Claude Partner Network certification card) -->
+  <script type="text/javascript" async src="https://www.credly.com/assets/utilities/embed.js"></script>
 </body>
 </html>

--- a/_output/index.html
+++ b/_output/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jeremy Longshore - I Make Teams AI-Native</title>
-  <meta name="last-modified" content="2026-07-26T19:48:09-0600">
+  <meta name="last-modified" content="2026-07-26T20:09:48-0600">
   <meta name="theme-color" content="#FFFFFF">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="description" content="I build AI systems that ship and train teams to work with coding agents — Claude, Codex, Gemini, whatever moves the needle. 20+ years ops, self-taught dev, 60+ repos with real GitHub stars." />
@@ -15,7 +15,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="./images/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="./images/favicons/favicon-32x32.png">
   <link rel="shortcut icon" href="./images/favicons/favicon.ico">
-  <link rel="stylesheet" href="./styles.css?v=2026-07-26T19:48:09-0600" />
+  <link rel="stylesheet" href="./styles.css?v=2026-07-26T20:09:48-0600" />
 </head>
 <body>
   <div class="container">
@@ -1728,38 +1728,35 @@
     <nav class="socials">
       
       
-      <a href="https://github.com/jeremylongshore" target="_blank" title="Jeremy Longshore's GitHub" class="social-icon">
-        <i class="fa-brands fa-github"></i>
+      <a href="https://github.com/jeremylongshore" target="_blank" title="Jeremy Longshore's GitHub" class="social-icon"><i class="fa-brands fa-github"></i>
       </a>
       
       
-      <a href="https://github.com/intent-solutions-io" target="_blank" title="Intent Solutions GitHub Organization" class="social-icon">
-        <i class="fa-solid fa-building"></i>
+      <a href="https://github.com/intent-solutions-io" target="_blank" title="Intent Solutions GitHub Organization" class="social-icon"><i class="fa-solid fa-building"></i>
       </a>
       
       
-      <a href="https://linkedin.com/in/jeremylongshore" target="_blank" title="Jeremy Longshore's LinkedIn" class="social-icon">
-        <i class="fa-brands fa-linkedin"></i>
+      <a href="https://linkedin.com/in/jeremylongshore" target="_blank" title="Jeremy Longshore's LinkedIn" class="social-icon"><i class="fa-brands fa-linkedin"></i>
       </a>
       
       
-      <a href="https://www.upwork.com/freelancers/jeremylongshore" target="_blank" title="Hire Jeremy on Upwork" class="social-icon">
-        <i class="fa-brands fa-upwork"></i>
+      <a href="https://huggingface.co/intent-solutions-io" target="_blank" title="Intent Solutions on Hugging Face" class="social-icon social-icon--svg"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="1em" height="1em"><path fill="currentColor" d="M12 1.5c-3 0-5.6 1.7-6.9 4.2L3.5 4.6c-.5-.4-1.2-.3-1.6.2-.4.5-.3 1.2.2 1.6L4 8.1c-.3.9-.5 1.9-.5 3 0 4.7 3.8 8.5 8.5 8.5s8.5-3.8 8.5-8.5c0-1.1-.2-2.1-.5-3l1.9-1.7c.5-.4.6-1.1.2-1.6-.4-.5-1.1-.6-1.6-.2l-1.6 1.1C17.6 3.2 15 1.5 12 1.5zm-3.6 7.2c.6 0 1.1.5 1.1 1.1s-.5 1.1-1.1 1.1-1.1-.5-1.1-1.1.5-1.1 1.1-1.1zm7.2 0c.6 0 1.1.5 1.1 1.1s-.5 1.1-1.1 1.1-1.1-.5-1.1-1.1.5-1.1 1.1-1.1zM12 6c.6 0 1.1.5 1.1 1.1S12.6 8.2 12 8.2s-1.1-.5-1.1-1.1S11.4 6 12 6zm-3 6.5c.4 0 .7.2.9.5.5.7 1.3 1.2 2.1 1.2s1.6-.5 2.1-1.2c.4-.6 1.2-.7 1.7-.3.6.4.7 1.2.3 1.7-.9 1.3-2.5 2.1-4.1 2.1s-3.2-.8-4.1-2.1c-.4-.6-.2-1.4.3-1.7.2-.2.5-.2.8-.2z"/></svg>
       </a>
       
       
-      <a href="https://x.com/asphaltcowb0y" target="_blank" title="Jeremy Longshore's X (Twitter)" class="social-icon">
-        <i class="fa-brands fa-x-twitter"></i>
+      <a href="https://www.upwork.com/freelancers/jeremylongshore" target="_blank" title="Hire Jeremy on Upwork" class="social-icon"><i class="fa-brands fa-upwork"></i>
       </a>
       
       
-      <a href="https://discord.com/users/asphaltcowboy" target="_blank" title="Discord: asphaltcowboy" class="social-icon">
-        <i class="fa-brands fa-discord"></i>
+      <a href="https://x.com/asphaltcowb0y" target="_blank" title="Jeremy Longshore's X (Twitter)" class="social-icon"><i class="fa-brands fa-x-twitter"></i>
       </a>
       
       
-      <a href="mailto:jeremy@intentsolutions.io" target="_blank" title="Email: jeremy@intentsolutions.io" class="social-icon">
-        <i class="fa-solid fa-envelope"></i>
+      <a href="https://discord.com/users/asphaltcowboy" target="_blank" title="Discord: asphaltcowboy" class="social-icon"><i class="fa-brands fa-discord"></i>
+      </a>
+      
+      
+      <a href="mailto:jeremy@intentsolutions.io" target="_blank" title="Email: jeremy@intentsolutions.io" class="social-icon"><i class="fa-solid fa-envelope"></i>
       </a>
       
     </nav>

--- a/_output/styles.css
+++ b/_output/styles.css
@@ -1,277 +1,862 @@
-/* ============================================================
-   OPERATOR EDITORIAL — Jeremy Longshore
-   Warm paper · Fraunces display · Space Grotesk UI · one sharp red.
-   Anti-slop: no Inter, no gradients, no pill-soup, asymmetric.
-   ============================================================ */
-
-:root{
-  --paper:#faf8f4;
-  --paper-2:#f1ece3;
-  --ink:#1a1714;
-  --ink-soft:#3a342e;
-  --muted:#6b6358;
-  --faint:#9a9286;
-  --rule:#e4ddd2;
-  --accent:#c81e1e;
-  --serif:'Fraunces',Georgia,'Times New Roman',serif;
-  --sans:'Space Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
-  --maxw:720px;
+/* Braves Booth Theme - White background with Navy/Red/Gold accents */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
-*{margin:0;padding:0;box-sizing:border-box}
-a{color:inherit;text-decoration:none}
-
-body{
-  background:var(--paper);
-  color:var(--ink);
-  font-family:var(--sans);
-  -webkit-font-smoothing:antialiased;
-  text-rendering:optimizeLegibility;
-  padding:0 20px;
-  line-height:1.5;
-}
-.container{
-  width:100%;
-  max-width:var(--maxw);
-  margin:0 auto;
-  padding:64px 0 96px;
-  counter-reset:sec;
+/* Global link reset */
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-/* ---------- Header ---------- */
-.profile{
-  text-align:left;
-  border-bottom:2px solid var(--ink);
-  padding-bottom:26px;
-  margin-bottom:34px;
+body {
+  background: #FFFFFF;
+  color: #0C2340; /* Braves Navy */
+  min-height: 100vh;
+  padding: 40px 16px;
+  display: flex;
+  justify-content: center;
 }
-.avatar{
-  width:88px;height:88px;
-  object-fit:cover;
-  border-radius:6px;
-  margin-bottom:20px;
-  filter:grayscale(.15) contrast(1.03);
-}
-.profile h1{
-  font-family:var(--serif);
-  font-weight:600;
-  font-size:clamp(40px,9vw,62px);
-  line-height:.92;
-  letter-spacing:-.02em;
-  margin-bottom:16px;
-}
-.tagline{
-  font-size:clamp(16px,2.4vw,19px);
-  line-height:1.5;
-  color:var(--ink-soft);
-  max-width:30em;
-}
-.site-links{
-  margin-top:18px;
-  font-size:13px;
-  font-weight:600;
-  display:flex;
-  flex-wrap:wrap;
-  gap:0 6px;
-  align-items:center;
-  letter-spacing:.01em;
-}
-.site-links a{color:var(--accent);border-bottom:1px solid transparent;transition:border-color .15s}
-.site-links a:hover{border-color:var(--accent)}
-.site-links span{color:var(--faint);margin:0 4px}
 
-/* ---------- CTA buttons ---------- */
-.contact-cta{margin-top:38px;padding-top:28px;border-top:1px solid var(--rule);text-align:left}
-.contact-cta.top{margin:28px 0 44px;padding-top:0;border-top:none}
-.cta-buttons{display:flex;gap:12px;flex-wrap:wrap}
-.btn{
-  display:inline-flex;align-items:center;gap:9px;
-  font-family:var(--sans);font-size:14px;font-weight:600;
-  padding:13px 24px;border-radius:2px;cursor:pointer;
-  transition:background .15s,color .15s,transform .15s;
+.container {
+  width: 100%;
+  max-width: 680px;
 }
-.btn i{font-size:13px}
-.btn-primary{background:var(--ink);color:var(--paper);border:1.5px solid var(--ink)}
-.btn-primary:hover{background:var(--accent);border-color:var(--accent)}
-.btn-secondary{background:transparent;color:var(--ink);border:1.5px solid var(--ink)}
-.btn-secondary:hover{background:var(--ink);color:var(--paper)}
 
-/* ---------- Featured coaching (top of page) ---------- */
-.featured-coaching{
-  margin:0 0 50px;
-  padding:28px 30px 30px;
-  background:var(--paper-2);
-  border:1px solid var(--rule);
-  border-left:3px solid var(--accent);
-  border-radius:4px;
+/* Profile Header - Centered */
+.profile {
+  text-align: center;
+  margin-bottom: 32px;
 }
-.fc-eyebrow{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.16em;color:var(--accent)}
-.fc-title{font-family:var(--serif);font-weight:600;font-size:clamp(27px,5vw,38px);line-height:1.02;letter-spacing:-.015em;margin:10px 0 12px}
-.fc-desc{font-size:15px;line-height:1.6;color:var(--ink-soft);max-width:42em;margin-bottom:22px}
-.fc-actions{display:flex;gap:12px;flex-wrap:wrap}
 
-/* ---------- Framing blocks (approach / who-i-work-with) ---------- */
-.productivity-approach{margin-bottom:48px;padding-bottom:8px}
-.productivity-approach > h2,
-.who-i-work-with h2{
-  font-family:var(--serif);
-  font-weight:600;
-  font-size:26px;
-  line-height:1.1;
-  letter-spacing:-.01em;
-  margin-bottom:22px;
+.avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 12px;
+  border: 2px solid #e2e8f0;
 }
-.approach-grid{
-  display:grid;
-  grid-template-columns:repeat(2,1fr);
-  gap:0;
-  border-top:1px solid var(--rule);
-  margin-bottom:24px;
-}
-.approach-item{
-  padding:18px 18px 18px 0;
-  border-bottom:1px solid var(--rule);
-}
-.approach-item:nth-child(odd){border-right:1px solid var(--rule);padding-right:24px}
-.approach-item:nth-child(even){padding-left:24px}
-.approach-label{font-family:var(--serif);font-size:17px;font-weight:600;margin-bottom:6px}
-.approach-desc{font-size:13px;color:var(--muted);line-height:1.45}
-.philosophy p{font-size:15px;color:var(--ink-soft);margin-bottom:12px;max-width:40em}
-.philosophy ul{list-style:none}
-.philosophy li{font-size:14px;color:var(--muted);padding:5px 0 5px 22px;position:relative}
-.philosophy li::before{content:"\2192";position:absolute;left:0;color:var(--accent)}
 
-/* ---------- Section headers w/ editorial number rail ---------- */
-.links{margin-bottom:46px}
-.links + .links{margin-top:0}
-.section-header{
-  display:flex;align-items:baseline;justify-content:space-between;gap:14px;
-  border-bottom:1px solid var(--ink);
-  padding-bottom:12px;margin-bottom:6px;
+.profile h1 {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: #0C2340; /* Braves Navy */
 }
-a.section-header:hover .section-label{color:var(--accent)}
-.section-label{
-  font-family:var(--sans);
-  font-weight:600;
-  text-transform:uppercase;
-  letter-spacing:.16em;
-  font-size:12px;
-  color:var(--ink);
-  display:flex;align-items:baseline;gap:10px;
-  transition:color .15s;
+
+.tagline {
+  font-size: 15px;
+  color: #4a5568; /* Slate gray */
+  max-width: 400px;
+  margin: 0 auto;
+  line-height: 1.5;
 }
-.section-label::before{
-  counter-increment:sec;
-  content:counter(sec,decimal-leading-zero)" /";
-  font-family:var(--serif);
-  font-weight:600;
-  font-style:italic;
-  letter-spacing:0;
-  font-size:15px;
-  color:var(--accent);
+
+.site-links {
+  margin-top: 12px;
+  font-size: 13px;
+  color: #718096;
 }
-.section-header i{font-size:13px;color:var(--faint);transition:color .15s}
-a.section-header:hover i{color:var(--accent)}
-.contribution-count,.article-count{
-  font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;
-  color:var(--muted);white-space:nowrap;
+
+.site-links a {
+  color: #CE1141; /* Braves Red */
+  transition: color 0.15s;
 }
-.section-intro{font-size:14px;color:var(--muted);line-height:1.55;margin:14px 0 6px;max-width:42em}
 
-/* ---------- Project rows (hairline list, not boxes) ---------- */
-.link-item{
-  border-bottom:1px solid var(--rule);
-  transition:background .15s,padding .15s;
+.site-links a:hover {
+  color: #0C2340; /* Braves Navy */
 }
-.link-item:hover{background:linear-gradient(90deg,var(--paper-2),transparent)}
-.link-row{display:flex;align-items:center;gap:14px;padding:16px 6px;cursor:pointer;user-select:none}
-.link-item.simple{display:flex;align-items:center;gap:14px;padding:15px 6px}
-.link-item:hover .link-row,.link-item.simple:hover{padding-left:14px}
-.link-icon{
-  flex-shrink:0;width:22px;text-align:center;
-  color:var(--faint);font-size:15px;
+
+.site-links span {
+  margin: 0 8px;
+  color: #cbd5e0;
 }
-.link-item:hover .link-icon{color:var(--accent)}
-.link-text{flex:1;min-width:0;display:flex;flex-direction:column;gap:3px}
-.link-title{font-family:var(--serif);font-size:18px;font-weight:600;line-height:1.15;letter-spacing:-.01em}
-.link-desc{font-size:13px;color:var(--muted);line-height:1.4;overflow:hidden;text-overflow:ellipsis}
-.link-badge{flex-shrink:0;display:flex;align-items:center;gap:12px}
 
-/* stars as an editorial figure, not a pill */
-.badge{font-size:12px;font-weight:600;white-space:nowrap}
-.badge.stars{font-family:var(--serif);font-size:19px;font-weight:600;color:var(--ink)}
-.badge.stars::after{content:" \2605";font-size:12px;color:var(--accent);vertical-align:1px}
-.badge.private{font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--faint);border:1px solid var(--rule);padding:3px 8px;border-radius:2px}
-.badge.contrib{font-family:var(--serif);font-style:italic;color:var(--accent);font-size:14px}
-.badge.article-date{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint)}
-.expand-icon{
-  width:22px;height:22px;display:flex;align-items:center;justify-content:center;
-  font-size:18px;font-weight:300;color:var(--faint);line-height:1;
+/* Credly Badge — Claude Partner Network certification */
+.credly-card {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin: 24px auto 0;
+  max-width: 520px;
+  padding: 16px 20px;
+  background: #f7f8fa;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  text-align: left;
 }
-.link-item:hover .expand-icon{color:var(--ink)}
 
-/* ---------- Expand panel ---------- */
-.link-expand{max-height:0;overflow:hidden;transition:max-height .28s ease-out}
-.link-expand.open{max-height:560px}
-.link-expand > *{padding-left:6px;padding-right:6px}
-.expand-desc{font-size:14px;color:var(--ink-soft);line-height:1.6;padding:14px 6px 12px;border-top:1px solid var(--rule);margin-top:2px}
-.expand-list{list-style:none;padding-bottom:12px}
-.expand-list li{font-size:13px;color:var(--muted);padding:3px 0 3px 18px;position:relative}
-.expand-list li::before{content:"\2192";position:absolute;left:0;color:var(--accent);font-size:11px}
-.expand-tags{display:flex;flex-wrap:wrap;gap:6px;padding-bottom:14px}
-.tag{font-size:11px;font-weight:500;letter-spacing:.02em;padding:3px 9px;border-radius:2px;border:1px solid var(--rule);color:var(--muted);background:transparent}
-.tag.agent{border-color:var(--accent);color:var(--accent)}
-.expand-link{display:inline-block;font-family:var(--serif);font-style:italic;font-size:14px;color:var(--accent);padding-bottom:16px}
-.expand-link:hover{text-decoration:underline}
-
-/* contributions footer */
-.contributions-footer{display:flex;flex-wrap:wrap;gap:7px;padding:14px 6px 4px}
-.contrib-other{font-size:12px;color:var(--muted);padding:4px 10px;border:1px solid var(--rule);border-radius:2px;transition:border-color .15s,color .15s}
-.contrib-other:hover{border-color:var(--accent);color:var(--accent)}
-
-/* ---------- Who I work with ---------- */
-.who-i-work-with{margin-top:52px;padding-top:32px;border-top:2px solid var(--ink)}
-.who-i-work-with p{font-size:15px;color:var(--ink-soft);line-height:1.6;margin-bottom:12px;max-width:42em}
-.who-i-work-with ul{list-style:none;margin-bottom:24px}
-.who-i-work-with li{font-size:15px;color:var(--muted);padding:6px 0 6px 24px;position:relative}
-.who-i-work-with li::before{content:"\2192";position:absolute;left:0;color:var(--accent)}
-.cta-link{
-  display:inline-block;font-family:var(--sans);font-size:14px;font-weight:600;
-  color:var(--paper);background:var(--ink);padding:13px 26px;border-radius:2px;
-  transition:background .15s;
+.credly-badge {
+  flex: 0 0 auto;
+  width: 150px;
+  min-height: 270px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.cta-link:hover{background:var(--accent)}
 
-/* ---------- Work diary ---------- */
-.work-diary{margin-top:46px}
-.article-footer{padding:14px 0 4px}
-
-/* ---------- Socials ---------- */
-.socials{display:flex;gap:10px;margin:48px 0 8px}
-.social-icon{
-  width:44px;height:44px;display:flex;align-items:center;justify-content:center;
-  background:var(--ink);color:var(--paper);border-radius:3px;font-size:17px;
-  transition:background .15s,transform .15s;
+.credly-badge > div {
+  width: 150px;
+  height: 270px;
 }
-.social-icon:hover{background:var(--accent);transform:translateY(-2px)}
 
-/* ---------- Footer ---------- */
-footer{margin-top:44px;padding-top:26px;border-top:2px solid var(--ink);text-align:left;font-size:14px;line-height:1.65;color:var(--muted)}
-footer a{color:var(--accent);font-weight:600}
-footer a:hover{text-decoration:underline}
-.copyright{margin-top:10px;font-size:12px;color:var(--faint)}
-.copyright a{color:var(--muted)}
-.copyright a:hover{color:var(--accent)}
+.credly-meta {
+  flex: 1 1 auto;
+  min-width: 0;
+}
 
-/* ---------- Mobile ---------- */
-@media(max-width:520px){
-  .container{padding:44px 0 72px}
-  .featured-coaching{padding:22px 20px 24px}
-  .approach-grid{grid-template-columns:1fr}
-  .approach-item:nth-child(odd){border-right:none;padding-right:0}
-  .approach-item:nth-child(even){padding-left:0}
-  .cta-buttons{flex-direction:column}
-  .btn{width:100%;justify-content:center}
-  .link-title{font-size:16px}
-  .badge.stars{font-size:17px}
+.credly-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #CE1141; /* Braves Red — eyebrow accent */
+  margin-bottom: 4px;
+}
+
+.credly-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #0C2340; /* Braves Navy */
+  line-height: 1.35;
+  margin-bottom: 6px;
+}
+
+.credly-desc {
+  font-size: 13px;
+  color: #4a5568; /* Slate gray */
+  line-height: 1.5;
+  margin: 0 0 8px 0;
+}
+
+.credly-link {
+  font-size: 12px;
+  font-weight: 600;
+  color: #CE1141; /* Braves Red */
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.credly-link:hover {
+  color: #0C2340; /* Braves Navy */
+  text-decoration: underline;
+}
+
+/* Productivity Approach Section */
+.productivity-approach {
+  margin-bottom: 40px;
+  padding: 24px;
+  background: #f7f8fa;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+.productivity-approach h2 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0C2340; /* Braves Navy */
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.approach-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.approach-item {
+  padding: 16px;
+  background: #FFFFFF;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+}
+
+.approach-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0C2340; /* Braves Navy */
+  margin-bottom: 6px;
+}
+
+.approach-desc {
+  font-size: 13px;
+  color: #4a5568;
+  line-height: 1.4;
+}
+
+.philosophy {
+  padding-top: 16px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.philosophy p {
+  font-size: 14px;
+  color: #4a5568;
+  margin-bottom: 8px;
+}
+
+.philosophy ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.philosophy li {
+  font-size: 13px;
+  color: #4a5568;
+  padding: 4px 0 4px 20px;
+  position: relative;
+}
+
+.philosophy li::before {
+  content: "\2192";
+  position: absolute;
+  left: 0;
+  color: #CE1141; /* Braves Red */
+}
+
+/* Section Intro Text */
+.section-intro {
+  font-size: 14px;
+  color: #4a5568;
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+/* Who I Work With Section */
+.who-i-work-with {
+  margin-top: 40px;
+  padding: 24px;
+  background: #f7f8fa;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  text-align: center;
+}
+
+.who-i-work-with h2 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0C2340; /* Braves Navy */
+  margin-bottom: 16px;
+}
+
+.who-i-work-with p {
+  font-size: 14px;
+  color: #4a5568;
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+
+.who-i-work-with ul {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 20px;
+  text-align: left;
+  max-width: 360px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.who-i-work-with li {
+  font-size: 14px;
+  color: #4a5568;
+  padding: 6px 0 6px 24px;
+  position: relative;
+}
+
+.who-i-work-with li::before {
+  content: "\2192";
+  position: absolute;
+  left: 0;
+  color: #CE1141; /* Braves Red */
+}
+
+.cta-link {
+  display: inline-block;
+  font-size: 15px;
+  font-weight: 600;
+  color: #CE1141; /* Braves Red */
+  text-decoration: none;
+  padding: 12px 24px;
+  background: #FFFFFF;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.cta-link:hover {
+  background: #CE1141; /* Braves Red */
+  color: #FFFFFF;
+  border-color: #CE1141;
+}
+
+/* Links Section */
+.links {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #718096;
+  margin: 0;
+}
+
+/* Section Header with optional link */
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  padding: 8px 0;
+  text-decoration: none;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+a.section-header {
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+a.section-header:hover {
+  border-color: #CE1141; /* Braves Red */
+}
+
+a.section-header:hover .section-label {
+  color: #CE1141; /* Braves Red */
+}
+
+.section-header i {
+  font-size: 14px;
+  color: #cbd5e0;
+  transition: color 0.15s;
+}
+
+a.section-header:hover i {
+  color: #CE1141; /* Braves Red */
+}
+
+/* Contribution count badge in section header */
+.contribution-count {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 10px;
+  background: #E8F5E9;
+  color: #2E7D32;
+}
+
+/* Contributions footer - smaller links */
+.contributions-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 16px;
+  background: #f7f8fa;
+  border-radius: 8px;
+  margin-top: 4px;
+}
+
+.contrib-other {
+  font-size: 12px;
+  color: #718096;
+  text-decoration: none;
+  padding: 4px 10px;
+  background: #FFFFFF;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.contrib-other:hover {
+  color: #CE1141; /* Braves Red */
+  border-color: #CE1141;
+}
+
+/* Add spacing between sections */
+.links + .links {
+  margin-top: 32px;
+}
+
+/* Link Item Card */
+.link-item {
+  background: #f7f8fa;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: transform 0.1s, box-shadow 0.15s, background 0.15s;
+  border: 1px solid #e2e8f0;
+}
+
+.link-item:hover {
+  background: #FFFFFF;
+  border-color: #CE1141; /* Braves Red */
+  box-shadow: 0 2px 8px rgba(12, 35, 64, 0.08);
+}
+
+.link-item:active {
+  transform: scale(0.98);
+}
+
+/* Link Row - Tap Target */
+.link-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  min-height: 64px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.link-item.simple {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  min-height: 56px;
+  text-decoration: none;
+}
+
+/* Icon */
+.link-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0C2340; /* Braves Navy */
+  border-radius: 10px;
+  font-size: 18px;
+  color: #FFFFFF;
+}
+
+/* Text */
+.link-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.link-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #0C2340; /* Braves Navy */
+}
+
+.link-desc {
+  font-size: 13px;
+  color: #4a5568;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Badge */
+.link-badge {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.badge {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
+.badge.stars {
+  background: #FFF8E1;
+  color: #B8860B;
+}
+
+.badge.private {
+  background: #f7f8fa;
+  color: #718096;
+  border: 1px solid #e2e8f0;
+}
+
+.badge.contrib {
+  background: #E8F5E9;
+  color: #2E7D32;
+}
+
+.badge.date {
+  background: #EDE7F6;
+  color: #5E35B1;
+  font-variant-numeric: tabular-nums;
+}
+
+.blog-section .section-intro {
+  margin-bottom: 4px;
+}
+
+.view-all-link {
+  display: block;
+  text-align: center;
+  margin-top: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #2563EB;
+  text-decoration: none;
+  padding: 8px;
+}
+.view-all-link:hover {
+  text-decoration: underline;
+}
+
+.expand-icon {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 300;
+  color: #718096;
+}
+
+/* Expanded Content */
+.link-expand {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease-out;
+}
+
+.link-expand.open {
+  max-height: 500px;
+}
+
+.link-expand > * {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.expand-desc {
+  font-size: 14px;
+  color: #4a5568;
+  line-height: 1.5;
+  padding-top: 4px;
+  padding-bottom: 12px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.expand-list {
+  list-style: none;
+  padding-bottom: 12px;
+}
+
+.expand-list li {
+  font-size: 13px;
+  color: #4a5568;
+  padding: 3px 0 3px 16px;
+  position: relative;
+}
+
+.expand-list li::before {
+  content: "\2192";
+  position: absolute;
+  left: 0;
+  color: #CE1141; /* Braves Red */
+  font-size: 11px;
+}
+
+.expand-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-bottom: 12px;
+}
+
+.tag {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+
+.tag.tech {
+  background: #E3F2FD;
+  color: #1565C0;
+}
+
+.tag.agent {
+  background: #E8F5E9;
+  color: #2E7D32;
+}
+
+.expand-link {
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 500;
+  color: #CE1141; /* Braves Red */
+  padding-bottom: 16px;
+  text-decoration: none;
+}
+
+.expand-link:hover {
+  text-decoration: underline;
+  color: #A00D33;
+}
+
+/* Socials */
+.socials {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.social-icon {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f7f8fa;
+  border: 1px solid #e2e8f0;
+  border-radius: 50%;
+  color: #4a5568;
+  font-size: 20px;
+  transition: transform 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.social-icon:hover {
+  transform: scale(1.1);
+  background: #0C2340; /* Braves Navy */
+  color: #FFFFFF;
+  border-color: #0C2340;
+}
+
+/* Contact CTA */
+.contact-cta {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid #e2e8f0;
+  text-align: center;
+}
+
+.contact-cta.top {
+  margin-top: 0;
+  margin-bottom: 32px;
+  padding-top: 0;
+  border-top: none;
+}
+
+.cta-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  min-height: 48px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none !important;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-appearance: none;
+  cursor: pointer;
+  transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
+}
+
+.btn:link,
+.btn:visited,
+.btn:hover,
+.btn:active {
+  text-decoration: none !important;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(12, 35, 64, 0.15);
+}
+
+.btn:active {
+  transform: scale(0.98);
+}
+
+.btn:focus {
+  outline: 2px solid #CE1141; /* Braves Red */
+  outline-offset: 2px;
+}
+
+.btn:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.btn-primary {
+  background: #CE1141 !important; /* Braves Red */
+  color: #FFFFFF !important;
+  border: none;
+}
+
+.btn-primary:link,
+.btn-primary:visited,
+.btn-primary:active {
+  background: #CE1141 !important;
+  color: #FFFFFF !important;
+}
+
+.btn-primary:hover {
+  background: #A00D33 !important; /* Darker Red */
+  color: #FFFFFF !important;
+}
+
+.btn-secondary {
+  background: transparent !important;
+  color: #0C2340 !important; /* Braves Navy */
+  border: 1px solid #0C2340 !important;
+}
+
+.btn-secondary:link,
+.btn-secondary:visited,
+.btn-secondary:active {
+  background: transparent !important;
+  color: #0C2340 !important;
+}
+
+.btn-secondary:hover {
+  background: #0C2340 !important; /* Braves Navy */
+  color: #FFFFFF !important;
+}
+
+/* Footer */
+footer {
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 1px solid #e2e8f0;
+  text-align: center;
+  font-size: 14px;
+  color: #718096;
+  line-height: 1.6;
+}
+
+footer a {
+  color: #CE1141; /* Braves Red */
+  text-decoration: none;
+}
+
+footer a:hover {
+  color: #0C2340; /* Braves Navy */
+  text-decoration: underline;
+}
+
+.copyright {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #a0aec0;
+}
+
+.copyright a {
+  color: #718096;
+}
+
+.copyright a:hover {
+  color: #CE1141; /* Braves Red */
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  body {
+    padding: 24px 12px;
+  }
+
+  .avatar {
+    width: 80px;
+    height: 80px;
+  }
+
+  .profile h1 {
+    font-size: 22px;
+  }
+
+  .approach-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .productivity-approach,
+  .who-i-work-with {
+    padding: 20px 16px;
+  }
+
+  .link-row,
+  .link-item.simple {
+    padding: 12px 14px;
+    gap: 12px;
+  }
+
+  .link-icon {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+  }
+
+  .link-title {
+    font-size: 14px;
+  }
+
+  .link-desc {
+    font-size: 12px;
+  }
+
+  .socials {
+    gap: 12px;
+  }
+
+  .social-icon {
+    width: 40px;
+    height: 40px;
+    font-size: 18px;
+  }
+
+  .cta-buttons {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .btn {
+    width: 100%;
+    justify-content: center;
+    min-height: 48px;
+    padding: 14px 24px;
+  }
+
+  .credly-card {
+    flex-direction: column;
+    text-align: center;
+    padding: 18px 16px;
+  }
+
+  .credly-badge {
+    margin: 0 auto;
+  }
+
+  .credly-eyebrow,
+  .credly-title,
+  .credly-desc,
+  .credly-link {
+    text-align: center;
+  }
 }

--- a/_output/styles.css
+++ b/_output/styles.css
@@ -642,6 +642,14 @@ a.section-header:hover i {
   border-color: #0C2340;
 }
 
+/* Inline-SVG variant of .social-icon (for brand marks that aren't in FA —
+   e.g. Hugging Face). Inherits width/height/color from .social-icon. */
+.social-icon--svg svg {
+  width: 1em;
+  height: 1em;
+  display: block;
+}
+
 /* Contact CTA */
 .contact-cta {
   margin-top: 32px;

--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,22 @@ socials:
       alt: "Jeremy Longshore's LinkedIn"
       target: "_blank"
   - social:
+      icon: >-
+        svg:<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+        aria-hidden="true" focusable="false" width="1em" height="1em"><path
+        fill="currentColor" d="M12 1.5c-3 0-5.6 1.7-6.9 4.2L3.5 4.6c-.5-.4-1.2-.3-1.6.2-.4.5-.3
+        1.2.2 1.6L4 8.1c-.3.9-.5 1.9-.5 3 0 4.7 3.8 8.5 8.5 8.5s8.5-3.8 8.5-8.5c0-1.1-.2-2.1-.5-3l1.9-1.7c.5-.4.6-1.1.2-1.6-.4-.5-1.1-.6-1.6-.2l-1.6
+        1.1C17.6 3.2 15 1.5 12 1.5zm-3.6 7.2c.6 0 1.1.5 1.1 1.1s-.5
+        1.1-1.1 1.1-1.1-.5-1.1-1.1.5-1.1 1.1-1.1zm7.2 0c.6 0 1.1.5 1.1
+        1.1s-.5 1.1-1.1 1.1-1.1-.5-1.1-1.1.5-1.1 1.1-1.1zM12 6c.6 0 1.1.5 1.1
+        1.1S12.6 8.2 12 8.2s-1.1-.5-1.1-1.1S11.4 6 12 6zm-3 6.5c.4 0 .7.2.9.5.5.7
+        1.3 1.2 2.1 1.2s1.6-.5 2.1-1.2c.4-.6 1.2-.7 1.7-.3.6.4.7 1.2.3
+        1.7-.9 1.3-2.5 2.1-4.1 2.1s-3.2-.8-4.1-2.1c-.4-.6-.2-1.4.3-1.7.2-.2.5-.2.8-.2z"/></svg>
+      url: "https://huggingface.co/intent-solutions-io"
+      title: "Intent Solutions on Hugging Face"
+      alt: "Intent Solutions on Hugging Face"
+      target: "_blank"
+  - social:
       icon: "fa-brands fa-upwork"
       url: "https://www.upwork.com/freelancers/jeremylongshore"
       title: "Hire Jeremy on Upwork"

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ title }}</title>
   <meta name="last-modified" content="{{ last_modified_at }}">
-  <meta name="theme-color" content="#faf8f4">
+  <meta name="theme-color" content="#FFFFFF">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="description" content="{{ tagline }}" />
   <meta property="og:title" content="{{ title }}" />
@@ -15,9 +15,6 @@
   <link rel="apple-touch-icon" sizes="180x180" href="./images/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="./images/favicons/favicon-32x32.png">
   <link rel="shortcut icon" href="./images/favicons/favicon.ico">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./styles.css?v={{ last_modified_at }}" />
 </head>
 <body>
@@ -33,6 +30,18 @@
         <span>·</span>
         <a href="https://startaitools.com" target="_blank">startaitools.com</a>
       </p>
+
+      <aside class="credly-card" aria-label="Claude Partner Network certification">
+        <div class="credly-badge">
+          <div data-iframe-width="150" data-iframe-height="270" data-share-badge-id="ddf22fb4-0aa6-46b3-a93b-0b45b509e471" data-share-badge-host="https://www.credly.com"></div>
+        </div>
+        <div class="credly-meta">
+          <div class="credly-eyebrow">Anthropic-issued</div>
+          <div class="credly-title">Claude Partner Badge &middot; Claude Code</div>
+          <p class="credly-desc">Certified through the Claude Partner Network to scope, deploy, configure, and run Claude Code activations end-to-end. Eight-course program with a scenario-based capstone.</p>
+          <a class="credly-link" href="https://www.credly.com/badges/ddf22fb4-0aa6-46b3-a93b-0b45b509e471" target="_blank" rel="noopener noreferrer">Verify on Credly &rarr;</a>
+        </div>
+      </aside>
     </header>
 
     <section class="contact-cta top">
@@ -43,16 +52,6 @@
         <a href="{{ contact_url }}" target="_blank" class="btn btn-secondary">
           <i class="fa-solid fa-envelope"></i> Send a Message
         </a>
-      </div>
-    </section>
-
-    <section class="featured-coaching">
-      <span class="fc-eyebrow">Learn with Jeremy</span>
-      <h2 class="fc-title">Your project. My methodology.</h2>
-      <p class="fc-desc">1:1 coaching on AI coding agents &mdash; Claude Code, Codex, Gemini, whatever moves the needle. You bring your real codebase; I bring the methodology that actually ships. Starter, Standard, and full-day deep dives.</p>
-      <div class="fc-actions">
-        <a href="{{ booking_url }}" target="_blank" class="btn btn-primary"><i class="fa-solid fa-calendar"></i> Book a session</a>
-        <a href="https://www.upwork.com/freelancers/jeremylongshore" target="_blank" class="btn btn-secondary">See the tiers</a>
       </div>
     </section>
 
@@ -187,7 +186,6 @@
         <h2 class="section-label">Products</h2>
       </div>
       {% for p in products %}
-      {% unless p.id == 'learn-with-jeremy' %}
       <div class="link-item" data-id="{{ p.id }}">
         <div class="link-row" onclick="toggleExpand('{{ p.id }}')">
           <div class="link-icon"><i class="{{ p.icon }}"></i></div>
@@ -224,34 +222,33 @@
           <a href="{{ p.url }}" target="_blank" class="expand-link">Open &rarr;</a>
         </div>
       </div>
-      {% endunless %}
       {% endfor %}
     </section>
     {% endif %}
 
-    {% assign contrib = vars.GithubContributionsPlugin %}
-    {% if contrib and contrib.total_prs > 0 %}
+    {% if contributions.highlights.size > 0 %}
     <section class="links">
-      <a href="https://github.com/pulls?q=is%3Apr%20author%3Ajeremylongshore%20is%3Amerged" target="_blank" class="section-header">
+      <div class="section-header">
         <h2 class="section-label">Open Source Contributions</h2>
-        <span class="contribution-count">{{ contrib.total_prs }} PRs &middot; {{ contrib.total_repos }} repos</span>
-      </a>
-      {% for c in contrib.highlights %}
+        <span class="contribution-count">{{ contributions.total_prs }} PRs merged</span>
+      </div>
+      {% for c in contributions.highlights %}
       <a href="{{ c.url }}" target="_blank" class="link-item simple">
         <div class="link-icon"><i class="{{ c.icon }}"></i></div>
         <div class="link-text">
-          <span class="link-title">{{ c.label }}</span>
+          <span class="link-title">{{ c.title }}</span>
           <span class="link-desc">{{ c.description }}</span>
         </div>
         <div class="link-badge">
-          <span class="badge contrib">{{ c.count }} PR{% unless c.count == 1 %}s{% endunless %}</span>
+          {% if c.prs %}<span class="badge contrib">{{ c.prs }} PRs</span>
+          {% else %}<span class="badge contrib">#{{ c.pr_number }}</span>{% endif %}
         </div>
       </a>
       {% endfor %}
-      {% if contrib.others.size > 0 %}
+      {% if contributions.others.size > 0 %}
       <div class="contributions-footer">
-        {% for o in contrib.others %}
-        <a href="{{ o.url }}" target="_blank" class="contrib-other">{{ o.name }} &middot; {{ o.count }}</a>
+        {% for o in contributions.others %}
+        <a href="{{ o.url }}" target="_blank" class="contrib-other">{{ o.repo | split: "/" | last }}: {{ o.note }}</a>
         {% endfor %}
       </div>
       {% endif %}
@@ -331,31 +328,6 @@
     </section>
     {% endif %}
 
-    {% if articles.size > 0 %}
-    <section class="links work-diary">
-      <a href="https://startaitools.com" target="_blank" class="section-header">
-        <h2 class="section-label">Work Diary</h2>
-        <span class="article-count">{{ articles.size }} latest</span>
-      </a>
-      <p class="section-intro">What I'm building, breaking, and shipping — direct from the commit log.</p>
-      {% for article in articles %}
-      <a href="{{ article.url }}" target="_blank" class="link-item simple article-item">
-        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
-        <div class="link-text">
-          <span class="link-title">{{ article.title }}</span>
-          <span class="link-desc">{{ article.description }}</span>
-        </div>
-        <div class="link-badge">
-          <span class="badge article-date">{{ article.date }}</span>
-        </div>
-      </a>
-      {% endfor %}
-      <div class="article-footer">
-        <a href="https://startaitools.com" target="_blank" class="expand-link">Read all posts →</a>
-      </div>
-    </section>
-    {% endif %}
-
     <section class="who-i-work-with">
       <h2>Who I Work With</h2>
       <p>I work with organizations adopting AI — from startups building their first agent to enterprises rolling out coding tools across 500 engineers.</p>
@@ -367,6 +339,29 @@
       </ul>
       <a href="{{ booking_url }}" target="_blank" class="cta-link">Let's talk →</a>
     </section>
+
+    {% if blog_posts.size > 0 %}
+    <section class="links blog-section">
+      <a href="https://startaitools.com/posts/" target="_blank" class="section-header">
+        <h2 class="section-label">Latest Writing</h2>
+        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+      </a>
+      <p class="section-intro">Technical deep-dives on AI agents, plugin development, and production systems.</p>
+      {% for post in blog_posts %}
+      <a href="{{ post.url }}" target="_blank" class="link-item simple">
+        <div class="link-icon"><i class="fa-solid fa-pen-nib"></i></div>
+        <div class="link-text">
+          <span class="link-title">{{ post.title }}</span>
+          <span class="link-desc">{{ post.description }}</span>
+        </div>
+        <div class="link-badge">
+          <span class="badge date">{{ post.date }}</span>
+        </div>
+      </a>
+      {% endfor %}
+      <a href="https://startaitools.com/posts/" target="_blank" class="view-all-link">View all posts →</a>
+    </section>
+    {% endif %}
 
     <nav class="socials">
       {% for item in socials %}
@@ -411,6 +406,8 @@
     gtag('config', '{{ google_analytics_id }}');
   </script>
   {% endif %}
-  <script defer src="https://analytics.intentsolutions.io/script.js" data-website-id="3cea8ff2-5842-4090-a8a3-d2dc128f5385"></script>
+
+  <!-- Credly badge embed (Claude Partner Network certification card) -->
+  <script type="text/javascript" async src="https://www.credly.com/assets/utilities/embed.js"></script>
 </body>
 </html>

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -366,8 +366,12 @@
     <nav class="socials">
       {% for item in socials %}
       {% assign s = item.social %}
-      <a href="{{ s.url }}" target="{{ s.target }}" title="{{ s.title }}" class="social-icon">
+      <a href="{{ s.url }}" target="{{ s.target }}" title="{{ s.title }}" class="social-icon{% if s.icon contains 'svg:' %} social-icon--svg{% endif %}">
+        {%- if s.icon contains 'svg:' -%}
+        {{ s.icon | remove: 'svg:' }}
+        {%- else -%}
         <i class="{{ s.icon }}"></i>
+        {%- endif %}
       </a>
       {% endfor %}
     </nav>

--- a/themes/default/styles.css
+++ b/themes/default/styles.css
@@ -1,277 +1,862 @@
-/* ============================================================
-   OPERATOR EDITORIAL — Jeremy Longshore
-   Warm paper · Fraunces display · Space Grotesk UI · one sharp red.
-   Anti-slop: no Inter, no gradients, no pill-soup, asymmetric.
-   ============================================================ */
-
-:root{
-  --paper:#faf8f4;
-  --paper-2:#f1ece3;
-  --ink:#1a1714;
-  --ink-soft:#3a342e;
-  --muted:#6b6358;
-  --faint:#9a9286;
-  --rule:#e4ddd2;
-  --accent:#c81e1e;
-  --serif:'Fraunces',Georgia,'Times New Roman',serif;
-  --sans:'Space Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
-  --maxw:720px;
+/* Braves Booth Theme - White background with Navy/Red/Gold accents */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
-*{margin:0;padding:0;box-sizing:border-box}
-a{color:inherit;text-decoration:none}
-
-body{
-  background:var(--paper);
-  color:var(--ink);
-  font-family:var(--sans);
-  -webkit-font-smoothing:antialiased;
-  text-rendering:optimizeLegibility;
-  padding:0 20px;
-  line-height:1.5;
-}
-.container{
-  width:100%;
-  max-width:var(--maxw);
-  margin:0 auto;
-  padding:64px 0 96px;
-  counter-reset:sec;
+/* Global link reset */
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-/* ---------- Header ---------- */
-.profile{
-  text-align:left;
-  border-bottom:2px solid var(--ink);
-  padding-bottom:26px;
-  margin-bottom:34px;
+body {
+  background: #FFFFFF;
+  color: #0C2340; /* Braves Navy */
+  min-height: 100vh;
+  padding: 40px 16px;
+  display: flex;
+  justify-content: center;
 }
-.avatar{
-  width:88px;height:88px;
-  object-fit:cover;
-  border-radius:6px;
-  margin-bottom:20px;
-  filter:grayscale(.15) contrast(1.03);
-}
-.profile h1{
-  font-family:var(--serif);
-  font-weight:600;
-  font-size:clamp(40px,9vw,62px);
-  line-height:.92;
-  letter-spacing:-.02em;
-  margin-bottom:16px;
-}
-.tagline{
-  font-size:clamp(16px,2.4vw,19px);
-  line-height:1.5;
-  color:var(--ink-soft);
-  max-width:30em;
-}
-.site-links{
-  margin-top:18px;
-  font-size:13px;
-  font-weight:600;
-  display:flex;
-  flex-wrap:wrap;
-  gap:0 6px;
-  align-items:center;
-  letter-spacing:.01em;
-}
-.site-links a{color:var(--accent);border-bottom:1px solid transparent;transition:border-color .15s}
-.site-links a:hover{border-color:var(--accent)}
-.site-links span{color:var(--faint);margin:0 4px}
 
-/* ---------- CTA buttons ---------- */
-.contact-cta{margin-top:38px;padding-top:28px;border-top:1px solid var(--rule);text-align:left}
-.contact-cta.top{margin:28px 0 44px;padding-top:0;border-top:none}
-.cta-buttons{display:flex;gap:12px;flex-wrap:wrap}
-.btn{
-  display:inline-flex;align-items:center;gap:9px;
-  font-family:var(--sans);font-size:14px;font-weight:600;
-  padding:13px 24px;border-radius:2px;cursor:pointer;
-  transition:background .15s,color .15s,transform .15s;
+.container {
+  width: 100%;
+  max-width: 680px;
 }
-.btn i{font-size:13px}
-.btn-primary{background:var(--ink);color:var(--paper);border:1.5px solid var(--ink)}
-.btn-primary:hover{background:var(--accent);border-color:var(--accent)}
-.btn-secondary{background:transparent;color:var(--ink);border:1.5px solid var(--ink)}
-.btn-secondary:hover{background:var(--ink);color:var(--paper)}
 
-/* ---------- Featured coaching (top of page) ---------- */
-.featured-coaching{
-  margin:0 0 50px;
-  padding:28px 30px 30px;
-  background:var(--paper-2);
-  border:1px solid var(--rule);
-  border-left:3px solid var(--accent);
-  border-radius:4px;
+/* Profile Header - Centered */
+.profile {
+  text-align: center;
+  margin-bottom: 32px;
 }
-.fc-eyebrow{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.16em;color:var(--accent)}
-.fc-title{font-family:var(--serif);font-weight:600;font-size:clamp(27px,5vw,38px);line-height:1.02;letter-spacing:-.015em;margin:10px 0 12px}
-.fc-desc{font-size:15px;line-height:1.6;color:var(--ink-soft);max-width:42em;margin-bottom:22px}
-.fc-actions{display:flex;gap:12px;flex-wrap:wrap}
 
-/* ---------- Framing blocks (approach / who-i-work-with) ---------- */
-.productivity-approach{margin-bottom:48px;padding-bottom:8px}
-.productivity-approach > h2,
-.who-i-work-with h2{
-  font-family:var(--serif);
-  font-weight:600;
-  font-size:26px;
-  line-height:1.1;
-  letter-spacing:-.01em;
-  margin-bottom:22px;
+.avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 12px;
+  border: 2px solid #e2e8f0;
 }
-.approach-grid{
-  display:grid;
-  grid-template-columns:repeat(2,1fr);
-  gap:0;
-  border-top:1px solid var(--rule);
-  margin-bottom:24px;
-}
-.approach-item{
-  padding:18px 18px 18px 0;
-  border-bottom:1px solid var(--rule);
-}
-.approach-item:nth-child(odd){border-right:1px solid var(--rule);padding-right:24px}
-.approach-item:nth-child(even){padding-left:24px}
-.approach-label{font-family:var(--serif);font-size:17px;font-weight:600;margin-bottom:6px}
-.approach-desc{font-size:13px;color:var(--muted);line-height:1.45}
-.philosophy p{font-size:15px;color:var(--ink-soft);margin-bottom:12px;max-width:40em}
-.philosophy ul{list-style:none}
-.philosophy li{font-size:14px;color:var(--muted);padding:5px 0 5px 22px;position:relative}
-.philosophy li::before{content:"\2192";position:absolute;left:0;color:var(--accent)}
 
-/* ---------- Section headers w/ editorial number rail ---------- */
-.links{margin-bottom:46px}
-.links + .links{margin-top:0}
-.section-header{
-  display:flex;align-items:baseline;justify-content:space-between;gap:14px;
-  border-bottom:1px solid var(--ink);
-  padding-bottom:12px;margin-bottom:6px;
+.profile h1 {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: #0C2340; /* Braves Navy */
 }
-a.section-header:hover .section-label{color:var(--accent)}
-.section-label{
-  font-family:var(--sans);
-  font-weight:600;
-  text-transform:uppercase;
-  letter-spacing:.16em;
-  font-size:12px;
-  color:var(--ink);
-  display:flex;align-items:baseline;gap:10px;
-  transition:color .15s;
+
+.tagline {
+  font-size: 15px;
+  color: #4a5568; /* Slate gray */
+  max-width: 400px;
+  margin: 0 auto;
+  line-height: 1.5;
 }
-.section-label::before{
-  counter-increment:sec;
-  content:counter(sec,decimal-leading-zero)" /";
-  font-family:var(--serif);
-  font-weight:600;
-  font-style:italic;
-  letter-spacing:0;
-  font-size:15px;
-  color:var(--accent);
+
+.site-links {
+  margin-top: 12px;
+  font-size: 13px;
+  color: #718096;
 }
-.section-header i{font-size:13px;color:var(--faint);transition:color .15s}
-a.section-header:hover i{color:var(--accent)}
-.contribution-count,.article-count{
-  font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;
-  color:var(--muted);white-space:nowrap;
+
+.site-links a {
+  color: #CE1141; /* Braves Red */
+  transition: color 0.15s;
 }
-.section-intro{font-size:14px;color:var(--muted);line-height:1.55;margin:14px 0 6px;max-width:42em}
 
-/* ---------- Project rows (hairline list, not boxes) ---------- */
-.link-item{
-  border-bottom:1px solid var(--rule);
-  transition:background .15s,padding .15s;
+.site-links a:hover {
+  color: #0C2340; /* Braves Navy */
 }
-.link-item:hover{background:linear-gradient(90deg,var(--paper-2),transparent)}
-.link-row{display:flex;align-items:center;gap:14px;padding:16px 6px;cursor:pointer;user-select:none}
-.link-item.simple{display:flex;align-items:center;gap:14px;padding:15px 6px}
-.link-item:hover .link-row,.link-item.simple:hover{padding-left:14px}
-.link-icon{
-  flex-shrink:0;width:22px;text-align:center;
-  color:var(--faint);font-size:15px;
+
+.site-links span {
+  margin: 0 8px;
+  color: #cbd5e0;
 }
-.link-item:hover .link-icon{color:var(--accent)}
-.link-text{flex:1;min-width:0;display:flex;flex-direction:column;gap:3px}
-.link-title{font-family:var(--serif);font-size:18px;font-weight:600;line-height:1.15;letter-spacing:-.01em}
-.link-desc{font-size:13px;color:var(--muted);line-height:1.4;overflow:hidden;text-overflow:ellipsis}
-.link-badge{flex-shrink:0;display:flex;align-items:center;gap:12px}
 
-/* stars as an editorial figure, not a pill */
-.badge{font-size:12px;font-weight:600;white-space:nowrap}
-.badge.stars{font-family:var(--serif);font-size:19px;font-weight:600;color:var(--ink)}
-.badge.stars::after{content:" \2605";font-size:12px;color:var(--accent);vertical-align:1px}
-.badge.private{font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--faint);border:1px solid var(--rule);padding:3px 8px;border-radius:2px}
-.badge.contrib{font-family:var(--serif);font-style:italic;color:var(--accent);font-size:14px}
-.badge.article-date{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint)}
-.expand-icon{
-  width:22px;height:22px;display:flex;align-items:center;justify-content:center;
-  font-size:18px;font-weight:300;color:var(--faint);line-height:1;
+/* Credly Badge — Claude Partner Network certification */
+.credly-card {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin: 24px auto 0;
+  max-width: 520px;
+  padding: 16px 20px;
+  background: #f7f8fa;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  text-align: left;
 }
-.link-item:hover .expand-icon{color:var(--ink)}
 
-/* ---------- Expand panel ---------- */
-.link-expand{max-height:0;overflow:hidden;transition:max-height .28s ease-out}
-.link-expand.open{max-height:560px}
-.link-expand > *{padding-left:6px;padding-right:6px}
-.expand-desc{font-size:14px;color:var(--ink-soft);line-height:1.6;padding:14px 6px 12px;border-top:1px solid var(--rule);margin-top:2px}
-.expand-list{list-style:none;padding-bottom:12px}
-.expand-list li{font-size:13px;color:var(--muted);padding:3px 0 3px 18px;position:relative}
-.expand-list li::before{content:"\2192";position:absolute;left:0;color:var(--accent);font-size:11px}
-.expand-tags{display:flex;flex-wrap:wrap;gap:6px;padding-bottom:14px}
-.tag{font-size:11px;font-weight:500;letter-spacing:.02em;padding:3px 9px;border-radius:2px;border:1px solid var(--rule);color:var(--muted);background:transparent}
-.tag.agent{border-color:var(--accent);color:var(--accent)}
-.expand-link{display:inline-block;font-family:var(--serif);font-style:italic;font-size:14px;color:var(--accent);padding-bottom:16px}
-.expand-link:hover{text-decoration:underline}
-
-/* contributions footer */
-.contributions-footer{display:flex;flex-wrap:wrap;gap:7px;padding:14px 6px 4px}
-.contrib-other{font-size:12px;color:var(--muted);padding:4px 10px;border:1px solid var(--rule);border-radius:2px;transition:border-color .15s,color .15s}
-.contrib-other:hover{border-color:var(--accent);color:var(--accent)}
-
-/* ---------- Who I work with ---------- */
-.who-i-work-with{margin-top:52px;padding-top:32px;border-top:2px solid var(--ink)}
-.who-i-work-with p{font-size:15px;color:var(--ink-soft);line-height:1.6;margin-bottom:12px;max-width:42em}
-.who-i-work-with ul{list-style:none;margin-bottom:24px}
-.who-i-work-with li{font-size:15px;color:var(--muted);padding:6px 0 6px 24px;position:relative}
-.who-i-work-with li::before{content:"\2192";position:absolute;left:0;color:var(--accent)}
-.cta-link{
-  display:inline-block;font-family:var(--sans);font-size:14px;font-weight:600;
-  color:var(--paper);background:var(--ink);padding:13px 26px;border-radius:2px;
-  transition:background .15s;
+.credly-badge {
+  flex: 0 0 auto;
+  width: 150px;
+  min-height: 270px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.cta-link:hover{background:var(--accent)}
 
-/* ---------- Work diary ---------- */
-.work-diary{margin-top:46px}
-.article-footer{padding:14px 0 4px}
-
-/* ---------- Socials ---------- */
-.socials{display:flex;gap:10px;margin:48px 0 8px}
-.social-icon{
-  width:44px;height:44px;display:flex;align-items:center;justify-content:center;
-  background:var(--ink);color:var(--paper);border-radius:3px;font-size:17px;
-  transition:background .15s,transform .15s;
+.credly-badge > div {
+  width: 150px;
+  height: 270px;
 }
-.social-icon:hover{background:var(--accent);transform:translateY(-2px)}
 
-/* ---------- Footer ---------- */
-footer{margin-top:44px;padding-top:26px;border-top:2px solid var(--ink);text-align:left;font-size:14px;line-height:1.65;color:var(--muted)}
-footer a{color:var(--accent);font-weight:600}
-footer a:hover{text-decoration:underline}
-.copyright{margin-top:10px;font-size:12px;color:var(--faint)}
-.copyright a{color:var(--muted)}
-.copyright a:hover{color:var(--accent)}
+.credly-meta {
+  flex: 1 1 auto;
+  min-width: 0;
+}
 
-/* ---------- Mobile ---------- */
-@media(max-width:520px){
-  .container{padding:44px 0 72px}
-  .featured-coaching{padding:22px 20px 24px}
-  .approach-grid{grid-template-columns:1fr}
-  .approach-item:nth-child(odd){border-right:none;padding-right:0}
-  .approach-item:nth-child(even){padding-left:0}
-  .cta-buttons{flex-direction:column}
-  .btn{width:100%;justify-content:center}
-  .link-title{font-size:16px}
-  .badge.stars{font-size:17px}
+.credly-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #CE1141; /* Braves Red — eyebrow accent */
+  margin-bottom: 4px;
+}
+
+.credly-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #0C2340; /* Braves Navy */
+  line-height: 1.35;
+  margin-bottom: 6px;
+}
+
+.credly-desc {
+  font-size: 13px;
+  color: #4a5568; /* Slate gray */
+  line-height: 1.5;
+  margin: 0 0 8px 0;
+}
+
+.credly-link {
+  font-size: 12px;
+  font-weight: 600;
+  color: #CE1141; /* Braves Red */
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.credly-link:hover {
+  color: #0C2340; /* Braves Navy */
+  text-decoration: underline;
+}
+
+/* Productivity Approach Section */
+.productivity-approach {
+  margin-bottom: 40px;
+  padding: 24px;
+  background: #f7f8fa;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+}
+
+.productivity-approach h2 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0C2340; /* Braves Navy */
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.approach-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.approach-item {
+  padding: 16px;
+  background: #FFFFFF;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+}
+
+.approach-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #0C2340; /* Braves Navy */
+  margin-bottom: 6px;
+}
+
+.approach-desc {
+  font-size: 13px;
+  color: #4a5568;
+  line-height: 1.4;
+}
+
+.philosophy {
+  padding-top: 16px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.philosophy p {
+  font-size: 14px;
+  color: #4a5568;
+  margin-bottom: 8px;
+}
+
+.philosophy ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.philosophy li {
+  font-size: 13px;
+  color: #4a5568;
+  padding: 4px 0 4px 20px;
+  position: relative;
+}
+
+.philosophy li::before {
+  content: "\2192";
+  position: absolute;
+  left: 0;
+  color: #CE1141; /* Braves Red */
+}
+
+/* Section Intro Text */
+.section-intro {
+  font-size: 14px;
+  color: #4a5568;
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+/* Who I Work With Section */
+.who-i-work-with {
+  margin-top: 40px;
+  padding: 24px;
+  background: #f7f8fa;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  text-align: center;
+}
+
+.who-i-work-with h2 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0C2340; /* Braves Navy */
+  margin-bottom: 16px;
+}
+
+.who-i-work-with p {
+  font-size: 14px;
+  color: #4a5568;
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+
+.who-i-work-with ul {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 20px;
+  text-align: left;
+  max-width: 360px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.who-i-work-with li {
+  font-size: 14px;
+  color: #4a5568;
+  padding: 6px 0 6px 24px;
+  position: relative;
+}
+
+.who-i-work-with li::before {
+  content: "\2192";
+  position: absolute;
+  left: 0;
+  color: #CE1141; /* Braves Red */
+}
+
+.cta-link {
+  display: inline-block;
+  font-size: 15px;
+  font-weight: 600;
+  color: #CE1141; /* Braves Red */
+  text-decoration: none;
+  padding: 12px 24px;
+  background: #FFFFFF;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.cta-link:hover {
+  background: #CE1141; /* Braves Red */
+  color: #FFFFFF;
+  border-color: #CE1141;
+}
+
+/* Links Section */
+.links {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #718096;
+  margin: 0;
+}
+
+/* Section Header with optional link */
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  padding: 8px 0;
+  text-decoration: none;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+a.section-header {
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+a.section-header:hover {
+  border-color: #CE1141; /* Braves Red */
+}
+
+a.section-header:hover .section-label {
+  color: #CE1141; /* Braves Red */
+}
+
+.section-header i {
+  font-size: 14px;
+  color: #cbd5e0;
+  transition: color 0.15s;
+}
+
+a.section-header:hover i {
+  color: #CE1141; /* Braves Red */
+}
+
+/* Contribution count badge in section header */
+.contribution-count {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 10px;
+  background: #E8F5E9;
+  color: #2E7D32;
+}
+
+/* Contributions footer - smaller links */
+.contributions-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 16px;
+  background: #f7f8fa;
+  border-radius: 8px;
+  margin-top: 4px;
+}
+
+.contrib-other {
+  font-size: 12px;
+  color: #718096;
+  text-decoration: none;
+  padding: 4px 10px;
+  background: #FFFFFF;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.contrib-other:hover {
+  color: #CE1141; /* Braves Red */
+  border-color: #CE1141;
+}
+
+/* Add spacing between sections */
+.links + .links {
+  margin-top: 32px;
+}
+
+/* Link Item Card */
+.link-item {
+  background: #f7f8fa;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: transform 0.1s, box-shadow 0.15s, background 0.15s;
+  border: 1px solid #e2e8f0;
+}
+
+.link-item:hover {
+  background: #FFFFFF;
+  border-color: #CE1141; /* Braves Red */
+  box-shadow: 0 2px 8px rgba(12, 35, 64, 0.08);
+}
+
+.link-item:active {
+  transform: scale(0.98);
+}
+
+/* Link Row - Tap Target */
+.link-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  min-height: 64px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.link-item.simple {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  min-height: 56px;
+  text-decoration: none;
+}
+
+/* Icon */
+.link-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0C2340; /* Braves Navy */
+  border-radius: 10px;
+  font-size: 18px;
+  color: #FFFFFF;
+}
+
+/* Text */
+.link-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.link-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #0C2340; /* Braves Navy */
+}
+
+.link-desc {
+  font-size: 13px;
+  color: #4a5568;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Badge */
+.link-badge {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.badge {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
+.badge.stars {
+  background: #FFF8E1;
+  color: #B8860B;
+}
+
+.badge.private {
+  background: #f7f8fa;
+  color: #718096;
+  border: 1px solid #e2e8f0;
+}
+
+.badge.contrib {
+  background: #E8F5E9;
+  color: #2E7D32;
+}
+
+.badge.date {
+  background: #EDE7F6;
+  color: #5E35B1;
+  font-variant-numeric: tabular-nums;
+}
+
+.blog-section .section-intro {
+  margin-bottom: 4px;
+}
+
+.view-all-link {
+  display: block;
+  text-align: center;
+  margin-top: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #2563EB;
+  text-decoration: none;
+  padding: 8px;
+}
+.view-all-link:hover {
+  text-decoration: underline;
+}
+
+.expand-icon {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 300;
+  color: #718096;
+}
+
+/* Expanded Content */
+.link-expand {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease-out;
+}
+
+.link-expand.open {
+  max-height: 500px;
+}
+
+.link-expand > * {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.expand-desc {
+  font-size: 14px;
+  color: #4a5568;
+  line-height: 1.5;
+  padding-top: 4px;
+  padding-bottom: 12px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.expand-list {
+  list-style: none;
+  padding-bottom: 12px;
+}
+
+.expand-list li {
+  font-size: 13px;
+  color: #4a5568;
+  padding: 3px 0 3px 16px;
+  position: relative;
+}
+
+.expand-list li::before {
+  content: "\2192";
+  position: absolute;
+  left: 0;
+  color: #CE1141; /* Braves Red */
+  font-size: 11px;
+}
+
+.expand-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-bottom: 12px;
+}
+
+.tag {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+
+.tag.tech {
+  background: #E3F2FD;
+  color: #1565C0;
+}
+
+.tag.agent {
+  background: #E8F5E9;
+  color: #2E7D32;
+}
+
+.expand-link {
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 500;
+  color: #CE1141; /* Braves Red */
+  padding-bottom: 16px;
+  text-decoration: none;
+}
+
+.expand-link:hover {
+  text-decoration: underline;
+  color: #A00D33;
+}
+
+/* Socials */
+.socials {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.social-icon {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f7f8fa;
+  border: 1px solid #e2e8f0;
+  border-radius: 50%;
+  color: #4a5568;
+  font-size: 20px;
+  transition: transform 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.social-icon:hover {
+  transform: scale(1.1);
+  background: #0C2340; /* Braves Navy */
+  color: #FFFFFF;
+  border-color: #0C2340;
+}
+
+/* Contact CTA */
+.contact-cta {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid #e2e8f0;
+  text-align: center;
+}
+
+.contact-cta.top {
+  margin-top: 0;
+  margin-bottom: 32px;
+  padding-top: 0;
+  border-top: none;
+}
+
+.cta-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  min-height: 48px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none !important;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-appearance: none;
+  cursor: pointer;
+  transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
+}
+
+.btn:link,
+.btn:visited,
+.btn:hover,
+.btn:active {
+  text-decoration: none !important;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(12, 35, 64, 0.15);
+}
+
+.btn:active {
+  transform: scale(0.98);
+}
+
+.btn:focus {
+  outline: 2px solid #CE1141; /* Braves Red */
+  outline-offset: 2px;
+}
+
+.btn:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.btn-primary {
+  background: #CE1141 !important; /* Braves Red */
+  color: #FFFFFF !important;
+  border: none;
+}
+
+.btn-primary:link,
+.btn-primary:visited,
+.btn-primary:active {
+  background: #CE1141 !important;
+  color: #FFFFFF !important;
+}
+
+.btn-primary:hover {
+  background: #A00D33 !important; /* Darker Red */
+  color: #FFFFFF !important;
+}
+
+.btn-secondary {
+  background: transparent !important;
+  color: #0C2340 !important; /* Braves Navy */
+  border: 1px solid #0C2340 !important;
+}
+
+.btn-secondary:link,
+.btn-secondary:visited,
+.btn-secondary:active {
+  background: transparent !important;
+  color: #0C2340 !important;
+}
+
+.btn-secondary:hover {
+  background: #0C2340 !important; /* Braves Navy */
+  color: #FFFFFF !important;
+}
+
+/* Footer */
+footer {
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 1px solid #e2e8f0;
+  text-align: center;
+  font-size: 14px;
+  color: #718096;
+  line-height: 1.6;
+}
+
+footer a {
+  color: #CE1141; /* Braves Red */
+  text-decoration: none;
+}
+
+footer a:hover {
+  color: #0C2340; /* Braves Navy */
+  text-decoration: underline;
+}
+
+.copyright {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #a0aec0;
+}
+
+.copyright a {
+  color: #718096;
+}
+
+.copyright a:hover {
+  color: #CE1141; /* Braves Red */
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  body {
+    padding: 24px 12px;
+  }
+
+  .avatar {
+    width: 80px;
+    height: 80px;
+  }
+
+  .profile h1 {
+    font-size: 22px;
+  }
+
+  .approach-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .productivity-approach,
+  .who-i-work-with {
+    padding: 20px 16px;
+  }
+
+  .link-row,
+  .link-item.simple {
+    padding: 12px 14px;
+    gap: 12px;
+  }
+
+  .link-icon {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+  }
+
+  .link-title {
+    font-size: 14px;
+  }
+
+  .link-desc {
+    font-size: 12px;
+  }
+
+  .socials {
+    gap: 12px;
+  }
+
+  .social-icon {
+    width: 40px;
+    height: 40px;
+    font-size: 18px;
+  }
+
+  .cta-buttons {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .btn {
+    width: 100%;
+    justify-content: center;
+    min-height: 48px;
+    padding: 14px 24px;
+  }
+
+  .credly-card {
+    flex-direction: column;
+    text-align: center;
+    padding: 18px 16px;
+  }
+
+  .credly-badge {
+    margin: 0 auto;
+  }
+
+  .credly-eyebrow,
+  .credly-title,
+  .credly-desc,
+  .credly-link {
+    text-align: center;
+  }
 }

--- a/themes/default/styles.css
+++ b/themes/default/styles.css
@@ -642,6 +642,14 @@ a.section-header:hover i {
   border-color: #0C2340;
 }
 
+/* Inline-SVG variant of .social-icon (for brand marks that aren't in FA —
+   e.g. Hugging Face). Inherits width/height/color from .social-icon. */
+.social-icon--svg svg {
+  width: 1em;
+  height: 1em;
+  display: block;
+}
+
 /* Contact CTA */
 .contact-cta {
   margin-top: 32px;


### PR DESCRIPTION
## What
Two additive changes to the personal portfolio page:

1. **Claude Partner Network certification card** in the profile header (badge + Anthropic-issued explainer wrapped in an on-brand credential card).
2. **Hugging Face brand icon** in the social nav (new entry between LinkedIn and Upwork; inline SVG since FontAwesome free doesn't include HF).

## Why
The Claude Partner Network cert was earned through Anthropic's 8-course program with a scenario-based capstone. Adding it as a structured card lifts it from "raw iframe sticker" to "real credential."

Intent Solutions also hosts an Astro landing-page mirror + README wrapper on Hugging Face Spaces. Adding an HF link to the social nav makes that surface addressable from the canonical personal portfolio.

## Where

### Badge (changes 1–3 below)
- `themes/default/index.html` — new `<aside class="credly-card">` inside `<header class="profile">` between `.site-links` and the contact CTA. Includes the Credly `embed.js` loader at the bottom of `<body>`.
- `themes/default/styles.css` — new `.credly-card` + `.credly-*` family. Two-column flex on desktop, stacks centered on ≤480px. Reuses Braves Navy + Braves Red tokens.
- `_output/index.html` + `_output/styles.css` — regenerated via `bundle exec ruby ./scaffold.rb`.

### Hugging Face social (changes 4–7 below)
- `config.yml` — new socials entry with `svg:`-prefixed icon (Hugging Face face SVG).
- `themes/default/index.html` — socials loop now branches on `svg:` prefix: inline the body when present, otherwise wrap in `<i class="...">`. Adds `.social-icon--svg` class for sizing.
- `themes/default/styles.css` — `.social-icon--svg svg` rule sets `width/height: 1em` so the inline SVG inherits the `.social-icon` font-size.
- `_output/*` — regenerated.

## How it works

### Badge
Flex card with the Credly iframe on the left (150px fixed) and credential meta on the right (flex 1 1 auto): eyebrow ("Anthropic-issued"), title ("Claude Partner Badge · Claude Code"), description (one-paragraph cap+deliverables summary), and a verify link to the public Credly URL. Loaded on every page since this site's homepage IS the profile page.

### HF social
The `svg:` prefix on `config.yml`'s icon key is the extension point. Any future brand missing from FontAwesome (Substack, Patreon, etc.) can follow the same pattern — drop the SVG body in `config.yml` with `svg:` prefix, and the template inlines it instead of wrapping in `<i class="...">`.

## Verification

**Local build:**
```
$ bundle exec ruby ./scaffold.rb  # exits 0, regenerates _output/
```

**Render check on `_output/index.html`:**
- `<aside class="credly-card">` with Anthropic-issued / Claude Partner Badge / Verify on Credly copy inside `<header class="profile">`.
- 1 `.social-icon--svg` anchor pointing at `huggingface.co/intent-solutions-io` with full inline HF face SVG body.
- All 6 `.credly-*` CSS rules present in `_output/styles.css`.
- `.social-icon--svg svg` rule present in `_output/styles.css`.
- YAML config validates: 8 socials total (GitHub × 2, LinkedIn, HF, Upwork, X, Discord, Email).

**Visual proof pending:** VPS deploy after merge.

## Risk
- **Low.** Pure markup + CSS + a third-party embed + a third-party icon. No schema, no DB, no dependency upgrade.
- **No secret leak** — Credly badge + HF org are public.
- **Embed costs**: Credly ~10KB async JS (loads on every page since home = profile page); HF icon is inline SVG (zero extra request).
- **Backwards compatible**: zero structural changes to existing sections; both changes are purely additive.

## Operational impact
- Deploy: merges to `main` → VPS deploy workflow fires.
- No migrations, no env changes, no new deps.
- Post-merge verify: visit `https://jeremylongshore.com/` and confirm (a) the badge card renders in the profile header with the Anthropic-issued eyebrow + verify link and (b) the HF icon appears in the social nav between LinkedIn and Upwork with the right brand mark.

## Follow-up
- If the Claude cert gets re-issued / re-branded, the data-share-badge-id in `themes/default/index.html` is the single edit point. Re-run `scaffold.rb`.
- If a second HF-hosted surface ships later, consider promoting HF into the `.site-links` row in the profile header.

## Refs
- Companion PRs:
  - `jeremylongshore/startaitools.com#36` — Claude Partner Badge on `/about/`
  - `jeremylongshore/startaitools.com#37` — Hugging Face link on `/about/` Connect block
- Anthropic Claude Partner Network program (badge `ddf22fb4-0aa6-46b3-a93b-0b45b509e471`, issued to Jeremy Longshore).
- Intent Solutions on Hugging Face: https://huggingface.co/intent-solutions-io

- Jeremy Longshore
intentsolutions.io