### PR TITLE
ci(workflows): SHA-pin actions/checkout + setup-python + ruby/setup-ruby (closes startaitools-tnt)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,8 @@ jobs:
     name: pre-deploy build gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0 — includes 2026-07-20 backport of allow-unsafe-pr-checkout
+      - uses: ruby/setup-ruby@b007fae6f1ffbe3a51c00a6df6f5ff01184d5340 # v1
         with:
           ruby-version: '3.2'
           bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0 — includes 2026-07-20 backport of allow-unsafe-pr-checkout
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sync-startaitools.yml
+++ b/.github/workflows/sync-startaitools.yml
@@ -9,10 +9,10 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0 — includes 2026-07-20 backport of allow-unsafe-pr-checkout
         with:
           submodules: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - run: pip install requests beautifulsoup4


### PR DESCRIPTION
## What
Mirrors startaitools.com#39: SHA-pin all 4 floating `actions/*` and `ruby/*` references in the three workflow files. Replaces `@v4` and `@v5` floats with specific commit SHAs (tag preserved as trailing comment).

## Why
Closes `startaitools-tnt`. Same vulnerability surface and same fix as #39 — the 2026-07-20 `actions/checkout` backport (v4.4.0 / v6.1.0 / v5.1.0 / v7.0.1) carries the safer `pull_request_target` defaults. Pinning ensures the SHA absorbs the backport whether or not a future workflow adds `pull_request_target`.

Also matches the project supply-chain rule (CLAUDE.md: enforce SHA-pin per Anthropic-style hardening). Floats are out; SHAs only move via PR.

## Where
- `deploy.yml` (lines 29, 30): actions/checkout, ruby/setup-ruby
- `release.yml` (line 36): actions/checkout, `with: fetch-depth: 0` preserved
- `sync-startaitools.yml` (lines 12, 15): actions/checkout `with: submodules: true` preserved, actions/setup-python `with: python-version: 3.11` preserved

## How
Each `uses:` line now reads `uses: <owner>/<repo>@<40-hex-sha>  # <tag> — <why>`. Tags include the version and an inline comment for the unsafe-default backport. Verified each SHA via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`:

| File | Action | Tag | SHA |
|---|---|---|---|
| deploy.yml | actions/checkout | v4.4.0 | `11d5960` |
| deploy.yml | ruby/setup-ruby | v1 | `b007fae6` |
| release.yml | actions/checkout | v4.4.0 | `11d5960` |
| sync-startaitools.yml | actions/checkout | v4.4.0 | `11d5960` |
| sync-startaitools.yml | actions/setup-python | v5 | `a26af69` |

All `actions/checkout` SHAs are at-or-after the 2026-07-20 backport.

## Why v4.4.0 + setup-ruby@v1 (not v6.1.0 + v2)
Conservative — no major-version jumps bundled with the pin. This repo deploys `_output/` via Tailscale OIDC + force-command and uses the bundle install + ruby scaffold.rb toolchain. v4 / setup-ruby@v1 is the working pair; the v4→v6 migration belongs in a separate PR.

## Verification
- `python3 -c "yaml.safe_load(...)"` parses every workflow clean.
- All 4 anchored `uses:` lines now match `uses: <action>@<40-hex-sha>\b` per the org-wide pinning convention.
- `with:` blocks (fetch-depth, submodules, python-version, ruby-version, bundler-cache) preserved verbatim — no semantic runtime change.

## Risk
- **Very low.** SHA-pinning is hardening. The semantic action surface at SHA v4.4.0 / v5.0.0 / setup-ruby v1 is identical to v4 / v5 / setup-ruby v1 respectively.
- **Recovery**: if a SHA turns out broken, the bump is a one-line change in this diff.

## Drift surfaced (NOT in this PR)
- jeremylongshore.com has no PR-only CI gate (no `pull_request:` trigger, no shellcheck / actionlint enforcement). File a follow-up bead for "add CI gate to jeremylongshore.com" mirroring the startaitools.com v1 gate if desired.

Refs:
- startaitools.com#39 (the canonical PR this mirrors)
- GitHub blog "Safer pull_request_target defaults":
  https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/
- bead: startaitools-tnt

- Jeremy Longshore
intentsolutions.io