### PR TITLE
fix(data): use type=path for the Umami metrics endpoint

### DIFF
--- a/lib/data/umami-views.ts
+++ b/lib/data/umami-views.ts
@@ -2,12 +2,11 @@
  * New fetcher (no Ruby plugin precedent): per-URL pageview counts from a
  * self-hosted Umami v2 instance (analytics.intentsolutions.io).
  *
- * ASSUMPTION: Umami v2's `/api/websites/{id}/metrics?type=url` endpoint
+ * Umami's `/api/websites/{id}/metrics?type=path` endpoint (verified live 2026-08-02:
+ * this instance 400s on the older `type=url`, 200s on `type=path`)
  * returns an array of `{ x: string; y: number }` points, where `x` is the
  * page URL/path and `y` is the pageview count for that path over the
- * requested [startAt, endAt) window (both epoch milliseconds). This matches
- * Umami's documented "metrics" shape for the `url` type but was not smoke-
- * tested against a live instance (no UMAMI_* credentials were available in
+ * requested [startAt, endAt) window (both epoch milliseconds).
  * this environment) — verify against a real response before shipping.
  *
  * `startAt` defaults to 2024-01-01 (treated as "site epoch" — i.e. all-time
@@ -38,7 +37,7 @@ export async function getViewCounts(): Promise<Map<string, number>> {
   }
 
   const url = new URL(`/api/websites/${websiteId}/metrics`, baseUrl);
-  url.searchParams.set('type', 'url');
+  url.searchParams.set('type', 'path');
   url.searchParams.set('startAt', String(SITE_EPOCH_MS));
   url.searchParams.set('endAt', String(Date.now()));
 


### PR DESCRIPTION
## What
One-line fix: the Umami view-counts fetcher sent `type=url` to /metrics; this instance requires `type=path` (probed live: url→400, path→200). Doc comment updated to record the verification.

## Why
Flagged as the one unverified endpoint shape during the data-layer port (#22); the first VPS image build surfaced the 400 loudly as designed.

## Verification & evidence
Typecheck green; live smoke against the production instance returns 500 paths with real counts (`/` → 307 views). Merging this triggers the docker-variant deploy whose /api/healthz smoke is the end-to-end pipeline proof.

## Risk
None beyond the touched fetcher — it currently fails on every fetch; the fix can only improve it.

## Refs
Refs jeremylongshore/jeremylongshore.com#21

- Jeremy Longshore
intentsolutions.io