### PR TITLE
fix(projects): hide the star badge when a repo has zero stars

### DIFF
--- a/components/sections/ProjectsSection.tsx
+++ b/components/sections/ProjectsSection.tsx
@@ -49,7 +49,7 @@ export async function ProjectsSection() {
                   </div>
                   <p className="mt-3 grow text-base">{project.purposeShort}</p>
                   <div className="mt-4 flex flex-wrap items-center gap-2">
-                    {typeof starCount === 'number' && (
+                    {typeof starCount === 'number' && starCount > 0 && (
                       <span
                         className="font-mono text-sm"
                         style={{ color: 'var(--color-accent-strong)' }}


### PR DESCRIPTION
## What
One-line conditional: project cards render the ★ badge only when the live count is > 0.

## Why
The new flagship cards (Bob's Big Brain, Intent Eval Platform) showed '★ 0' — anti-proof on a page whose whole voice is claim → live number → link (000-docs/003 §3.6).

## Verification
Typecheck + name-leak gate green; CI on this PR proves the build. Presentation-only.

## Refs
Refs jeremylongshore/jeremylongshore.com#21

- Jeremy Longshore
intentsolutions.io