### PR TITLE
feat(contributions): promote NOW LMS to a highlighted contribution card

### DIFF
--- a/lib/data/github-contributions.ts
+++ b/lib/data/github-contributions.ts
@@ -51,6 +51,12 @@ export interface ContributionsResult {
  * presentation-only (label/description/icon/tags).
  */
 const META: Record<string, ContributionMeta> = {
+  'bmosoluciones/now-lms': {
+    label: 'NOW LMS',
+    description: 'i18n compile-at-boot fixes, enrollment integrity constraints, theme perf, and test coverage for the open-source learning management system',
+    icon: 'fa-solid fa-graduation-cap',
+    tags: ['Python', 'Flask', 'i18n'],
+  },
   'GoogleCloudPlatform/vertex-ai-samples': {
     label: 'Vertex AI Samples',
     description: 'ADK inline-source deployment tutorial for Agent Engine',


### PR DESCRIPTION
## What
Adds `bmosoluciones/now-lms` to the contributions META map, promoting it from the 'also merged in' tail to a highlight card (label, description, graduation-cap icon, Python/Flask/i18n tags). Counts remain live from the GitHub search API.

## Why
14 merged upstream PRs — the largest external contribution — was buried as a bare link. (The 42 PRs on the intent-solutions-io fork correctly stay excluded; only true external work counts.)

## Verification
Live fetch: highlights now lead with 'NOW LMS (14)'; typecheck + name-leak gate green; CI is the proving run. Presentation-only data change.

## Refs
Refs jeremylongshore/jeremylongshore.com#21

- Jeremy Longshore
intentsolutions.io