### PR TITLE
perf(design-system): pause idle accent-gradient cycles; run on interaction

### DIFF
--- a/components/AvatarRing.tsx
+++ b/components/AvatarRing.tsx
@@ -43,7 +43,7 @@ export function AvatarRing({
   const instanceSeed = seed ?? reactId;
 
   const overlayVisibility = active
-    ? 'opacity-100'
+    ? 'jl-cycle-active opacity-100'
     : 'opacity-0 transition-opacity duration-[var(--duration-hover)] ease-out group-hover:opacity-100';
 
   return (

--- a/components/PillButton.tsx
+++ b/components/PillButton.tsx
@@ -58,7 +58,7 @@ export function PillButton({
   const ring = (
     <span
       aria-hidden="true"
-      className="pointer-events-none absolute -inset-[2px] overflow-hidden rounded-full opacity-40 transition-opacity duration-[var(--duration-hover)] ease-out group-hover:opacity-90"
+      className="jl-cycle-active pointer-events-none absolute -inset-[2px] overflow-hidden rounded-full opacity-40 transition-opacity duration-[var(--duration-hover)] ease-out group-hover:opacity-90"
     >
       <span className="jl-conic-spin absolute inset-0">
         {ACCENT_GRADIENT_VARS.map((varName, index) => (

--- a/components/gradient-cycle.css
+++ b/components/gradient-cycle.css
@@ -16,6 +16,18 @@
   animation-duration: 24s;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
+  /* Paused at rest — ~30 cards x 12 layers of invisible infinite animation
+     cost ~3.7s of Style & Layout on the Lighthouse mobile trace. The cycle
+     only rewards interaction, so it runs only while interacted-with; the
+     negative per-instance delays still land each instance at a different
+     phase the moment it starts. */
+  animation-play-state: paused;
+}
+
+.group:hover .jl-accent-layer,
+.group:focus-within .jl-accent-layer,
+.jl-cycle-active .jl-accent-layer {
+  animation-play-state: running;
 }
 
 /*


### PR DESCRIPTION
## What
`.jl-accent-layer` animations default to paused and run on `.group:hover`/`:focus-within`, or via `.jl-cycle-active` (pill rings + active avatar rings keep their always-on cycle).

## Why + decision rationale
~30 cards × 12 invisible accent layers animating continuously cost ~3.7s of Style & Layout on the Lighthouse mobile trace (prod perf 66). Chose play-state gating over reducing layers because hover behavior and per-instance phase offsets are pixel-identical.

## Verification & evidence
Standalone-build Lighthouse before/after: perf 66 → 91, TBT 890ms → 150ms, Style & Layout 3,690ms → 598ms. Typecheck + build green; name-leak gate clean; CI is the proving run. Production Lighthouse re-read after deploy.

## Risk
CSS-only; worst case a cycle starts on hover instead of mid-flight — visually indistinguishable per the reveal's own 300ms fade-in.

## Refs
Refs jeremylongshore/jeremylongshore.com#21

- Jeremy Longshore
intentsolutions.io